### PR TITLE
MR-2528 Fixed problem with incorrect data for Schema.org in the posts

### DIFF
--- a/client/pages/blog/_uid.vue
+++ b/client/pages/blog/_uid.vue
@@ -156,6 +156,7 @@ export default {
         post.data.schema_org_snippets[0].single_snippet[0].text
       ) {
         jsonLd = post.data.schema_org_snippets[0].single_snippet[0].text;
+        jsonLd = jsonLd.substring(jsonLd.indexOf('{'), jsonLd.lastIndexOf('}') + 1); // extracting only JSON object from a snippet without extra characters
       } else {
         console.log('Schema.org is not defined');
       }


### PR DESCRIPTION
**Описание проблемы:**
В призмике, некоторые json данные для schema.org вписаны вместе с обёрткой `<script type="application/ld+json">JSON обьект</script>` . Но у нас уже итак эти данные в конечном итоге выводятся в `<script data-n-head="ssr" type="application/ld+json"></script>` узел. <br />
Получается что `<script type="application/ld+json">` тег дублируется внутри `<script type="application/ld+json">` тега. <br />
На это ругается SEO checker.

**Решение проблемы:**
Обработал `jsonLd` переменную в файле `client/pages/blog/_uid.vue (159 строка)` .  <br />
Вытаскиваю оттуда только JSON обьект, а всё остальное обрезается ( всё остальное это лишние запятые и html теги за пределами JSON обьекта ).