### PR TITLE
MR-2022 Fixed section with parallax effect for GoDee case

### DIFF
--- a/client/assets/styles/cases/godee/_styles.scss
+++ b/client/assets/styles/cases/godee/_styles.scss
@@ -152,6 +152,7 @@
   }
 
   &_parallax-image {
+    max-width: 100%;
     position: absolute;
     top: 0;
     left: -5px;

--- a/client/assets/styles/cases/godee/_styles.scss
+++ b/client/assets/styles/cases/godee/_styles.scss
@@ -127,7 +127,14 @@
     perspective: 300px;
   }
 
-  &_parallax-container {
+  &_content-layer {
+    position: relative;
+    z-index: 1;
+    background: #fff;
+  }
+
+  &_parallax-layer {
+    z-index: -9;
     height: 576px;
     max-width: 1440px;
     margin-left: auto;
@@ -135,7 +142,6 @@
     position: relative;
     -webkit-transform-style: preserve-3d;
     transform-style: preserve-3d;
-    overflow: hidden;
   }
 
   &_parallax-image-wrapper {
@@ -153,16 +159,9 @@
     bottom: 0;
     background: url('../../assets/img/Cases/godee/jpg/parallax.jpg');
     background-size: cover;
+    background-position: center;
     -webkit-transform: translateZ(-300px) scale(2);
     transform: translateZ(-300px) scale(2);
-    z-index: 3;
-  }
-
-  &_safari-parallax-image {
-    height: 576px;
-    max-width: 1440px;
-    background: url('../../assets/img/Cases/godee/jpg/parallax.jpg') no-repeat center;
-    background-size: cover;
   }
 
   &_html-video-wrapper,

--- a/client/assets/styles/cases/godee/_styles.scss
+++ b/client/assets/styles/cases/godee/_styles.scss
@@ -152,7 +152,6 @@
   }
 
   &_parallax-image {
-    max-width: 100%;
     position: absolute;
     top: 0;
     left: -5px;

--- a/client/pages/case-studies/godee.vue
+++ b/client/pages/case-studies/godee.vue
@@ -2,526 +2,529 @@
   <div class="case_root">
     <HeaderMain />
     <main class="case case_parallax" id="case-scroll-container" ref="main">
-      <CaseHeader logo="godee" videoName="godee-case-main-video.mp4">
-        <h1 class="case_header-title" slot="title">Convenient shuttle <br> bus service</h1>
-        <p class="case_header-description" slot="description">
-          Mad Devs helped GoDee with developing feature-rich software to re-invent <br> public mobility by building new smart ways of a daily commute.
-        </p>
-      </CaseHeader>
-      <div class="case_animation_block" id="case-first-section"></div>
-      <section class="container_regular">
-        <TextParagraph class="m-48_top media-m-24_top">
-          GoDee is a reliable way to commute in Ho Chi Minh City, Vietnam. Its shuttle buses take express routes that link the city’s major districts and popular destinations. GoDee helps riders save time, money and the planet due to its lower ecological impact.
-        </TextParagraph>
-        <TextQuote class="m-auto m-96_top m-96_bottom media-m-48_top media-m-48_bottom">
-          The app-based system allows users to find a route, select the time, book a seat and pay for the ride online.
-        </TextQuote>
-      </section>
-      <section class="container_regular">
-        <h2 class="case_title_h2 m-12_bottom">Issues and solution</h2>
-        <TextParagraph>
-          Transportation has become a major issue in Vietnam cities due to the rapid increase (36%) in urbanization. With its slow, unairconditioned, overcrowded public transport, commuters living in the suburbs were left with only 3 other alternatives: personal cars, motorbikes and taxis.
-        </TextParagraph>
-      </section>
-      <div class="case_parallax-container m-48_top media-m-24_top m-48_bottom media-m-24_bottom" v-if="!isSafari">
+      <div class="case_content-layer p-48_bottom media-p-24_bottom">
+        <CaseHeader logo="godee" videoName="godee-case-main-video.mp4">
+          <h1 class="case_header-title" slot="title">Convenient shuttle <br> bus service</h1>
+          <p class="case_header-description" slot="description">
+            Mad Devs helped GoDee with developing feature-rich software to re-invent <br> public mobility by building new smart ways of a daily commute.
+          </p>
+        </CaseHeader>
+        <div class="case_animation_block" id="case-first-section"></div>
+        <section class="container_regular">
+          <TextParagraph class="m-48_top media-m-24_top">
+            GoDee is a reliable way to commute in Ho Chi Minh City, Vietnam. Its shuttle buses take express routes that link the city’s major districts and popular destinations. GoDee helps riders save time, money and the planet due to its lower ecological impact.
+          </TextParagraph>
+          <TextQuote class="m-auto m-96_top m-96_bottom media-m-48_top media-m-48_bottom">
+            The app-based system allows users to find a route, select the time, book a seat and pay for the ride online.
+          </TextQuote>
+        </section>
+        <section class="container_regular">
+          <h2 class="case_title_h2 m-12_bottom">Issues and solution</h2>
+          <TextParagraph>
+            Transportation has become a major issue in Vietnam cities due to the rapid increase (36%) in urbanization. With its slow, unairconditioned, overcrowded public transport, commuters living in the suburbs were left with only 3 other alternatives: personal cars, motorbikes and taxis.
+          </TextParagraph>
+        </section>
+      </div>
+      <div class="case_parallax-layer">
         <div class="case_parallax-image-wrapper">
           <div class="case_parallax-image"></div>
         </div>
       </div>
-      <section class="container_full case_safari-parallax-image m-48_top media-m-24_top m-48_bottom media-m-24_bottom" v-else></section>
-      <section class="container_regular">
-        <Card class="case_issues-godee-card background-color-silver">
-          <CardIssuesGoDee />
-        </Card>
-        <Card class="background-color-orange">
-          <CardSolutionGoDee />
-        </Card>
-      </section>
-      <section class="container_full case_video-wrapper m-60_top media-m-24_top m-96_bottom media-m-48_bottom">
-        <iframe width="1440" height="809" src="https://www.youtube.com/embed/_XCRbXmTUwI" frameborder="0" allowfullscreen></iframe>
-      </section>
-      <section class="container_regular m-48_bottom">
-        <h2 class="case_title_h2 m-12_bottom">Mad Devs & GoDee collaboration </h2>
-        <TextParagraph>
-          Mad Devs consulted with GoDee in the project’s early stages to assist with the technology stack choice and step-by-step planning. Then, several of our positively mad developers worked on GoDee’s smart urban bus management system as an extended part of the team.
-        </TextParagraph>
-      </section>
-      <section class="container_regular">
-        <h3 class="case_title_h3 m-12_bottom">Minimum viable product MVP</h3>
-        <TextParagraph class="m-24_bottom media-m-12_bottom">
-          Before investing a considerable amount of money in building software, hiring personnel and acquiring minibuses, GoDee wanted to <nuxt-link :to="`/services#software-development`" class="case_link">develop an MVP</nuxt-link> to understand the market fit potential.
-        </TextParagraph>
-        <TextParagraph class="m-24_bottom">
-          Although services such as GoDee exist in other parts of the world, simulating these programs in Ho Chi Minh City was pointless because the city’s commuting culture is quite different. That’s why user feedback was crucial to its improvement and key to its current rapid growth.
-        </TextParagraph>
-        <div class="case_minimum-viable-product-cards">
-          <Card class="background-color-silver">
-            <CardGoDeeFeature title="Live chat feature" iconName="live-chat">
-              <TextParagraph>
-                Over the time period of three months, our integrated live chat feature collected extensive feedback from users to make white-collar workers’ commutes easier.
-              </TextParagraph>
-            </CardGoDeeFeature>
+      <div class="case_content-layer p-48_top media-p-24_top">
+        <section class="container_regular">
+          <Card class="case_issues-godee-card background-color-silver">
+            <CardIssuesGoDee />
           </Card>
-          <Card class="background-color-silver">
-            <CardGoDeeFeature title="Trip request" iconName="trip-request">
-              <TextParagraph>
-                This feature enabled GoDee to analyse the actual demand for travel to various Ho Chi Minh City districts.
-              </TextParagraph>
-            </CardGoDeeFeature>
+          <Card class="background-color-orange">
+            <CardSolutionGoDee />
           </Card>
-        </div>
-      </section>
-      <section class="container_full case_before-after-wrapper background-color-silver m-48_top media-m-20_top">
-        <h2 class="case_title_h2 m-24_bottom case_text-align-center">Before & After</h2>
-        <div class="container_regular">
-          <BeforeAfterImage
-            :baseWidth="'1000'"
-            :baseHeight="'578.47'"
-            :beforeImage="'Cases/godee/png/application-before.png'"
-            :afterImage="'Cases/godee/png/application-after.png'"
-            :alt="'GoDee Public Transportation App at 2018 and now.'"
-          />
-        </div>
-      </section>
-      <p class="case_image-description m-12_top m-104_bottom media-m-48_bottom">GoDee 2018 VS. GoDee {{ currentYear }}</p>
-      <section class="container_regular" ref="cardsRootElem">
-        <h3 class="case_title_h2 m-24_bottom case_text-align-center" ref="developmentGoalsTitle">Development goals</h3>
-        <div class="case_development-goals p-96_bottom media-p-48_bottom" ref="cardsContainer">
-          <div class="case_development-goals-left-column" ref="cardsLeftColumn">
+        </section>
+        <section class="container_full case_video-wrapper m-60_top media-m-24_top m-96_bottom media-m-48_bottom">
+          <iframe width="1440" height="809" src="https://www.youtube.com/embed/_XCRbXmTUwI" frameborder="0" allowfullscreen></iframe>
+        </section>
+        <section class="container_regular m-48_bottom">
+          <h2 class="case_title_h2 m-12_bottom">Mad Devs & GoDee collaboration </h2>
+          <TextParagraph>
+            Mad Devs consulted with GoDee in the project’s early stages to assist with the technology stack choice and step-by-step planning. Then, several of our positively mad developers worked on GoDee’s smart urban bus management system as an extended part of the team.
+          </TextParagraph>
+        </section>
+        <section class="container_regular">
+          <h3 class="case_title_h3 m-12_bottom">Minimum viable product MVP</h3>
+          <TextParagraph class="m-24_bottom media-m-12_bottom">
+            Before investing a considerable amount of money in building software, hiring personnel and acquiring minibuses, GoDee wanted to <nuxt-link :to="`/services#software-development`" class="case_link">develop an MVP</nuxt-link> to understand the market fit potential.
+          </TextParagraph>
+          <TextParagraph class="m-24_bottom">
+            Although services such as GoDee exist in other parts of the world, simulating these programs in Ho Chi Minh City was pointless because the city’s commuting culture is quite different. That’s why user feedback was crucial to its improvement and key to its current rapid growth.
+          </TextParagraph>
+          <div class="case_minimum-viable-product-cards">
             <Card class="background-color-silver">
-              <CardGoDeeFeature title="GPS" iconName="gps">
+              <CardGoDeeFeature title="Live chat feature" iconName="live-chat">
                 <TextParagraph>
-                  We use GPS data to track buses, and we have developed an algorithm that predicts bus travel/arrival time using a geocoding service that also calculates delays related to traffic jams and their severity. This predictor functionality calculates the estimated arrival time on specific routes. It allows our passengers to check whether their requested bus will arrive on time, considering traffic jams.
+                  Over the time period of three months, our integrated live chat feature collected extensive feedback from users to make white-collar workers’ commutes easier.
                 </TextParagraph>
               </CardGoDeeFeature>
             </Card>
             <Card class="background-color-silver">
-              <CardGoDeeFeature title="Payment method" iconName="payment-method">
-                <TextParagraph class="m-24_bottom media-m-12_bottom">
-                  Cashless payments are becoming more popular in Vietnam, so we have integrated Stripe service into GoDee, enabling passengers to pay with credit cards easily and quickly.
-                </TextParagraph>
+              <CardGoDeeFeature title="Trip request" iconName="trip-request">
                 <TextParagraph>
-                  We have also developed an API for flawless third-party service integration. Visa/Mastercard, AmEx, MoMo and JCB are integrated into the GoDee user app to facilitate cashless payments.
+                  This feature enabled GoDee to analyse the actual demand for travel to various Ho Chi Minh City districts.
                 </TextParagraph>
               </CardGoDeeFeature>
             </Card>
           </div>
-          <div class="case_development-goals-right-column" ref="cardsRightColumn">
-            <Card class="background-color-silver">
-              <CardGoDeeFeature title="Online time-tables & live location tracking" iconName="live-location-tacking">
-                <TextParagraph>
-                  To help make the GoDee app easier to use, we created a system that tracks bus locations in real time. This means that every user can book a seat as their bus approaches their location.
-                </TextParagraph>
-              </CardGoDeeFeature>
-            </Card>
-            <Card class="background-color-silver">
-              <CardGoDeeFeature title="Referrals" iconName="referrals">
-                <TextParagraph>
-                  To add to the commuter experience, inside the shuttle bus application, users can share referrals and get free rides as bonuses. After receiving a referral code from a referrer, the user can input the code from the booking confirmation as a promo code and enjoy one free ride. Meanwhile, referrers also receive a reward with "an “X" number of free rides.
-                </TextParagraph>
-              </CardGoDeeFeature>
-            </Card>
-            <Card class="background-color-silver">
-              <CardGoDeeFeature title="The best possible routes" iconName="possible-routes">
-                <TextParagraph>
-                  Depending on passengers’ requests, the system allows drivers to construct the best possible routes automatically. If there are no orders from passengers, drivers will skip stops along the route.
-                </TextParagraph>
-              </CardGoDeeFeature>
-            </Card>
+        </section>
+        <section class="container_full case_before-after-wrapper background-color-silver m-48_top media-m-20_top">
+          <h2 class="case_title_h2 m-24_bottom case_text-align-center">Before & After</h2>
+          <div class="container_regular">
+            <BeforeAfterImage
+              :baseWidth="'1000'"
+              :baseHeight="'578.47'"
+              :beforeImage="'Cases/godee/png/application-before.png'"
+              :afterImage="'Cases/godee/png/application-after.png'"
+              :alt="'GoDee Public Transportation App at 2018 and now.'"
+            />
           </div>
-        </div>
-      </section>
-      <section class="container_full background-color-black-godee p-100_top p-100_bottom media-p-48_top media-p-48_bottom">
-        <div class="container_regular">
-          <div class="case_preview-cards">
-            <div class="case_preview-cards-top-cards-wrapper">
-              <Card class="background-color-godee-black-card">
-                <CardGoDeePreview
-                  className="application-for-passengers"
-                  title="Mobile application for passengers"
-                  description="Ticket booking process is intuitive — the passenger needs to select the pick up and drop off points, choose the departure time in the schedule, and book the ticket. The most suitable route will be found automatically."
-                  pictureFolder="godee"
-                  fileName="application-for-passengers-card"
-                  fileExtension="png"
-                  :mobileImage="false"
-                  mobileImageName=""
-                  alt="GoDee: Bus Transit App for Passengers."
-                  :width="334"
-                  :height="211"
-                />
+        </section>
+        <p class="case_image-description m-12_top m-104_bottom media-m-48_bottom">GoDee 2018 VS. GoDee {{ currentYear }}</p>
+        <section class="container_regular" ref="cardsRootElem">
+          <h3 class="case_title_h2 m-24_bottom case_text-align-center" ref="developmentGoalsTitle">Development goals</h3>
+          <div class="case_development-goals p-96_bottom media-p-48_bottom" ref="cardsContainer">
+            <div class="case_development-goals-left-column" ref="cardsLeftColumn">
+              <Card class="background-color-silver">
+                <CardGoDeeFeature title="GPS" iconName="gps">
+                  <TextParagraph>
+                    We use GPS data to track buses, and we have developed an algorithm that predicts bus travel/arrival time using a geocoding service that also calculates delays related to traffic jams and their severity. This predictor functionality calculates the estimated arrival time on specific routes. It allows our passengers to check whether their requested bus will arrive on time, considering traffic jams.
+                  </TextParagraph>
+                </CardGoDeeFeature>
               </Card>
+              <Card class="background-color-silver">
+                <CardGoDeeFeature title="Payment method" iconName="payment-method">
+                  <TextParagraph class="m-24_bottom media-m-12_bottom">
+                    Cashless payments are becoming more popular in Vietnam, so we have integrated Stripe service into GoDee, enabling passengers to pay with credit cards easily and quickly.
+                  </TextParagraph>
+                  <TextParagraph>
+                    We have also developed an API for flawless third-party service integration. Visa/Mastercard, AmEx, MoMo and JCB are integrated into the GoDee user app to facilitate cashless payments.
+                  </TextParagraph>
+                </CardGoDeeFeature>
+              </Card>
+            </div>
+            <div class="case_development-goals-right-column" ref="cardsRightColumn">
+              <Card class="background-color-silver">
+                <CardGoDeeFeature title="Online time-tables & live location tracking" iconName="live-location-tacking">
+                  <TextParagraph>
+                    To help make the GoDee app easier to use, we created a system that tracks bus locations in real time. This means that every user can book a seat as their bus approaches their location.
+                  </TextParagraph>
+                </CardGoDeeFeature>
+              </Card>
+              <Card class="background-color-silver">
+                <CardGoDeeFeature title="Referrals" iconName="referrals">
+                  <TextParagraph>
+                    To add to the commuter experience, inside the shuttle bus application, users can share referrals and get free rides as bonuses. After receiving a referral code from a referrer, the user can input the code from the booking confirmation as a promo code and enjoy one free ride. Meanwhile, referrers also receive a reward with "an “X" number of free rides.
+                  </TextParagraph>
+                </CardGoDeeFeature>
+              </Card>
+              <Card class="background-color-silver">
+                <CardGoDeeFeature title="The best possible routes" iconName="possible-routes">
+                  <TextParagraph>
+                    Depending on passengers’ requests, the system allows drivers to construct the best possible routes automatically. If there are no orders from passengers, drivers will skip stops along the route.
+                  </TextParagraph>
+                </CardGoDeeFeature>
+              </Card>
+            </div>
+          </div>
+        </section>
+        <section class="container_full background-color-black-godee p-100_top p-100_bottom media-p-48_top media-p-48_bottom">
+          <div class="container_regular">
+            <div class="case_preview-cards">
+              <div class="case_preview-cards-top-cards-wrapper">
+                <Card class="background-color-godee-black-card">
+                  <CardGoDeePreview
+                    className="application-for-passengers"
+                    title="Mobile application for passengers"
+                    description="Ticket booking process is intuitive — the passenger needs to select the pick up and drop off points, choose the departure time in the schedule, and book the ticket. The most suitable route will be found automatically."
+                    pictureFolder="godee"
+                    fileName="application-for-passengers-card"
+                    fileExtension="png"
+                    :mobileImage="false"
+                    mobileImageName=""
+                    alt="GoDee: Bus Transit App for Passengers."
+                    :width="334"
+                    :height="211"
+                  />
+                </Card>
+                <Card class="background-color-godee-black-card">
+                  <CardGoDeePreview 
+                    className="application-for-drivers"
+                    title="Mobile applications for drivers"
+                    description="The drivers’ transit app enables them to pick up passengers from bus stops, according to their previously booked tickets."
+                    pictureFolder="godee"
+                    fileName="application-for-drivers-card"
+                    fileExtension="png"
+                    :mobileImage="false"
+                    mobileImageName=""
+                    alt="GoDee: Bus Drivers App."
+                    :width="313"
+                    :height="280"
+                  />
+                </Card>
+              </div>
               <Card class="background-color-godee-black-card">
                 <CardGoDeePreview 
-                  className="application-for-drivers"
-                  title="Mobile applications for drivers"
-                  description="The drivers’ transit app enables them to pick up passengers from bus stops, according to their previously booked tickets."
+                  className="godee-admin-panel"
+                  title="Intelligent management panel"
+                  description="Used to create routes, get reports and map current active routes."
                   pictureFolder="godee"
-                  fileName="application-for-drivers-card"
+                  fileName="godee-admin-panel-card"
                   fileExtension="png"
-                  :mobileImage="false"
-                  mobileImageName=""
-                  alt="GoDee: Bus Drivers App."
-                  :width="313"
-                  :height="280"
+                  :mobileImage="true"
+                  mobileImageName="godee-admin-panel-card-mobile"
+                  alt="GoDee: Bus App Management System."
+                  :width="695"
+                  :height="219"
                 />
               </Card>
             </div>
-            <Card class="background-color-godee-black-card">
-              <CardGoDeePreview 
-                className="godee-admin-panel"
-                title="Intelligent management panel"
-                description="Used to create routes, get reports and map current active routes."
-                pictureFolder="godee"
-                fileName="godee-admin-panel-card"
-                fileExtension="png"
-                :mobileImage="true"
-                mobileImageName="godee-admin-panel-card-mobile"
-                alt="GoDee: Bus App Management System."
-                :width="695"
-                :height="219"
-              />
-            </Card>
           </div>
-        </div>
-      </section>
-      <section class="container_regular">
-        <h3 class="case_title_h2 m-96_top media-m-48_top m-12_bottom">Intelligent management panel</h3>
-        <TextParagraph>
-          GoDee's rapid growth since its early stages required easy-to-scale business processes and automated route management. Although, in theory, everything can be done with an army of sales representatives and route operators, GoDee wanted to automate routine operations so it could expand to other cities and countries.
-        </TextParagraph>
-        <TextQuoteBox class="m-48_top m-48_bottom media-m-24_top media-m-24_bottom m-auto">
-          One manager and one customer support representative can manage more than ~2500 trip requests per month and ~25,000  passengers per month.
-        </TextQuoteBox>
-        <h3 class="case_title_h3 m-12_bottom">Smart route planning</h3>
-        <TextParagraph class="case_paragraph--bold">
-          How can we create profitable yet convenient user routes?
-        </TextParagraph>
-        <TextParagraph class="m-24_bottom media-m-12_bottom">
-          Let users send <span class="case_red-text">trip requests</span> and tell you what works for them. This feature was available initially through the MVP phase, and it enables GoDee route managers to build effective routes by understanding real commuter demand.
-        </TextParagraph>
-        <TextParagraph>
-          Inside the transportation application, users can submit a trip request with pick-up and drop-off locations at the desired time. The request is added to the list on the managers' dashboard.
-        </TextParagraph>
-      </section>
-      <section class="container_middle">
-        <div class="case_image-wrapper m-48_top media-m-24_top m-60_bottom media-m-24_bottom case_box-shadow">
-          <Picture 
-            pictureFolder="common"
-            fileName="safari-top-bar-white"
-            fileExtension="jpg"
-            alt="GoDee: Safari Browser Top Bar White."
-            :boxShadow="false"
-            :lazyLoading="false"
-            :borderRadius="false"
-            :width="1026"
-            :height="16.45"
-            :backgroundColor="true"
-          />
-          <Picture 
-            pictureFolder="godee"
-            fileName="godee-admin-panel"
-            fileExtension="jpg"
-            alt="GoDee: Bus Transit App Admin Panel."
-            :boxShadow="false"
-            :lazyLoading="false"
-            :borderRadius="false"
-            :width="1026"
-            :height="672"
-          />
-        </div>
-        <CardGoDeePrimsAlgorithm class="m-48_bottom media-m-24_bottom"/>
-        <div class="case_html-video-wrapper m-48_top media-m-24_top m-60_bottom media-m-24_bottom case_box-shadow">
-          <div class="case_video-flex-wrapper" v-if="isIphone">
+        </section>
+        <section class="container_regular">
+          <h3 class="case_title_h2 m-96_top media-m-48_top m-12_bottom">Intelligent management panel</h3>
+          <TextParagraph>
+            GoDee's rapid growth since its early stages required easy-to-scale business processes and automated route management. Although, in theory, everything can be done with an army of sales representatives and route operators, GoDee wanted to automate routine operations so it could expand to other cities and countries.
+          </TextParagraph>
+          <TextQuoteBox class="m-48_top m-48_bottom media-m-24_top media-m-24_bottom m-auto">
+            One manager and one customer support representative can manage more than ~2500 trip requests per month and ~25,000  passengers per month.
+          </TextQuoteBox>
+          <h3 class="case_title_h3 m-12_bottom">Smart route planning</h3>
+          <TextParagraph class="case_paragraph--bold">
+            How can we create profitable yet convenient user routes?
+          </TextParagraph>
+          <TextParagraph class="m-24_bottom media-m-12_bottom">
+            Let users send <span class="case_red-text">trip requests</span> and tell you what works for them. This feature was available initially through the MVP phase, and it enables GoDee route managers to build effective routes by understanding real commuter demand.
+          </TextParagraph>
+          <TextParagraph>
+            Inside the transportation application, users can submit a trip request with pick-up and drop-off locations at the desired time. The request is added to the list on the managers' dashboard.
+          </TextParagraph>
+        </section>
+        <section class="container_middle">
+          <div class="case_image-wrapper m-48_top media-m-24_top m-60_bottom media-m-24_bottom case_box-shadow">
             <Picture 
               pictureFolder="common"
               fileName="safari-top-bar-white"
               fileExtension="jpg"
               alt="GoDee: Safari Browser Top Bar White."
               :boxShadow="false"
-              :lazyLoading="true"
+              :lazyLoading="false"
               :borderRadius="false"
               :width="1026"
               :height="16.45"
               :backgroundColor="true"
             />
-            <img src="../../assets/img/Cases/godee/jpg/trip-request-map.jpg" class="case_img" alt="Trip Request Map" loading="lazy" width="1028" height="483.81">
-          </div>
-          <div class="case_video-flex-wrapper" v-else>
-            <Picture 
-              pictureFolder="common"
-              fileName="safari-top-bar-white"
-              fileExtension="jpg"
-              alt="GoDee: Safari Browser Top Bar White."
-              :boxShadow="false"
-              :lazyLoading="true"
-              :borderRadius="false"
-              :width="1026"
-              :height="16.45"
-              :backgroundColor="true"
-            />
-            <video
-              id="trip-request-map" 
-              class="case_html-video case_trip-request-video" 
-              width="100%" 
-              height="100%" 
-              loop="true"
-              muted="true"
-            >
-              <source :src="getPathTripRequestMapVideo" type="video/mp4">
-              Your browser does not support the video tag.
-            </video>
-          </div>
-        </div>
-      </section>
-      <section class="container_regular">
-        <h3 class="case_title_h3 m-12_bottom">Trips Monitor</h3>
-        <TextParagraph>
-          The Trips Monitor feature enables operators to track every bus in real time and collect data on late or early arrivals. More importantly, the operator can contact drivers or passengers quickly if necessary.
-        </TextParagraph>
-      </section>
-      <section class="container_middle m-48_top media-m-24_top m-48_bottom media-m-24_bottom">
-        <div class="case_html-video-wrapper case_box-shadow">
-          <div class="case_video-flex-wrapper" v-if="isIphone">
-            <Picture 
-              pictureFolder="common"
-              fileName="safari-top-bar-white"
-              fileExtension="jpg"
-              alt="GoDee: Safari Browser Top Bar White."
-              :boxShadow="false"
-              :lazyLoading="true"
-              :borderRadius="false"
-              :width="1026"
-              :height="16.45"
-              :backgroundColor="true"
-            />
-            <img src="../../assets/img/Cases/godee/jpg/trip-monitor.jpg" class="case_img" alt="Trip Monitor" loading="lazy" width="1028" height="483.81">
-          </div>
-          <div class="case_video-flex-wrapper" v-else>
-            <Picture 
-              pictureFolder="common"
-              fileName="safari-top-bar-white"
-              fileExtension="jpg"
-              alt="GoDee: Safari Browser Top Bar White."
-              :boxShadow="false"
-              :lazyLoading="true"
-              :borderRadius="false"
-              :width="1026"
-              :height="16.45"
-              :backgroundColor="true"
-            />
-            <video 
-              id="trip-monitor"
-              class="case_html-video"
-              width="100%"
-              height="100%"
-              loop="true"
-              muted="true"
-            >
-              <source :src="getPathTripMonitorVideo" type="video/mp4">
-              Your browser does not support the video tag.
-            </video>
-          </div>
-        </div>
-      </section>
-      <section class="container_regular">
-        <TextParagraph class="m-12_bottom">
-          The Trips Monitor dashboard displays the following information:
-        </TextParagraph>
-        <ListNumberedBox class="m-96_bottom media-m-48_bottom">
-          <ListNumberedItemBox>
-            Drivers' locations on mini map in real-time
-          </ListNumberedItemBox>
-          <ListNumberedItemBox>
-            Late and early departures of buses
-          </ListNumberedItemBox>
-          <ListNumberedItemBox>
-            Complete bus schedule weeks in advance
-          </ListNumberedItemBox>
-          <ListNumberedItemBox>
-            Notice to driver that a GoDee client has not been picked up at a bus stop
-          </ListNumberedItemBox>
-          <ListNumberedItemBox>
-            Number of passengers assigned to each stop and driver
-          </ListNumberedItemBox>
-          <ListNumberedItemBox>
-            Historical information through filters
-          </ListNumberedItemBox>
-        </ListNumberedBox>
-        <h3 class="case_title_h3">Route optimization</h3>
-      </section>
-      <section class="container_middle m-24_top media-m-12_top m-48_bottom media-m-24_bottom">
-        <div class="case_html-video-wrapper case_box-shadow">
-          <div class="case_video-flex-wrapper" v-if="isIphone">
-            <Picture 
-              pictureFolder="common"
-              fileName="safari-top-bar-white"
-              fileExtension="jpg"
-              alt="GoDee: Safari Browser Top Bar White."
-              :boxShadow="false"
-              :lazyLoading="true"
-              :borderRadius="false"
-              :width="1026"
-              :height="16.45"
-              :backgroundColor="true"
-            />
-            <img src="../../assets/img/Cases/godee/jpg/route-optimization.jpg" class="case_img" alt="Route Optimization" loading="lazy" width="1028" height="483.81">
-          </div>
-          <div class="case_video-flex-wrapper" v-else>
-            <Picture 
-              pictureFolder="common"
-              fileName="safari-top-bar-white"
-              fileExtension="jpg"
-              alt="GoDee: Safari Browser Top Bar White."
-              :boxShadow="false"
-              :lazyLoading="true"
-              :borderRadius="false"
-              :width="1026"
-              :height="16.45"
-              :backgroundColor="true"
-            />
-            <video 
-              id="route-optimization" 
-              class="case_html-video" 
-              width="100%" 
-              height="100%" 
-              loop="true" 
-              muted="true"
-            >
-              <source :src="getPathRouteOptimizationVideo" type="video/mp4">
-              Your browser does not support the video tag.
-            </video>
-          </div>
-        </div>
-      </section>
-      <section class="container_regular">
-        <TextParagraph>
-          With the help of detailed drivers' performance data, Mad Devs’ Pifia microservice enables route managers to optimize ETA (estimated time of arrival). Pifia shows more accurate arrival and departure times with just one click.
-        </TextParagraph>
-        <TextQuoteBox class="m-48_top m-96_bottom media-m-24_top media-m-72_bottom m-auto">
-          <span class="case_text-quote-break m-24_bottom media-m-12_bottom">Examples of early and late departure times:</span>
-          <span>If Pifia determines that a minibus is usually late due to increased traffic at 5:35 pm and not 5:30 pm, it alerts the route manager to shift the arrival time to 5:35 pm. Five minutes might sound minor, but these small optimizations add up.</span>
-        </TextQuoteBox>
-      </section>
-      <section class="container_full p-104_top p-100_bottom media-p-41_top media-p-24_bottom background-color-black-godee">
-        <section class="container_regular case_real-time-eta">
-          <div class="case_real-time-eta-text-content">
-            <h2 class="case_title_h2 m-24_bottom media-m-8_bottom case_real-time-eta-title">Real-time ETA</h2>
-            <TextParagraph class="m-24_bottom media-m-12_bottom" color="#a0a0a1">
-              In addition, Pifia shows in real time the approximate late/early departures.
-            </TextParagraph>
-            <TextParagraph class="m-24_bottom media-m-12_bottom" color="#a0a0a1">
-              Thus passengers who are waiting for the ride always know whether the bus is coming late and how long it will take.
-            </TextParagraph>
-            <TextParagraph color="#a0a0a1">
-              The information is displayed on their mobile application.
-            </TextParagraph>
-          </div>
-          <div class="case_phone-wrapper-eta-section">
             <Picture 
               pictureFolder="godee"
-              fileName="real-time-eta-phone"
-              fileExtension="png"
-              alt="GoDee: Bus Transit App in Vietnam."
+              fileName="godee-admin-panel"
+              fileExtension="jpg"
+              alt="GoDee: Bus Transit App Admin Panel."
               :boxShadow="false"
-              :lazyLoading="true"
-              :width="358.96"
-              :height="694.62"
-              :backgroundColor="false"
+              :lazyLoading="false"
+              :borderRadius="false"
+              :width="1026"
+              :height="672"
             />
           </div>
+          <CardGoDeePrimsAlgorithm class="m-48_bottom media-m-24_bottom"/>
+          <div class="case_html-video-wrapper m-48_top media-m-24_top m-60_bottom media-m-24_bottom case_box-shadow">
+            <div class="case_video-flex-wrapper" v-if="isIphone">
+              <Picture 
+                pictureFolder="common"
+                fileName="safari-top-bar-white"
+                fileExtension="jpg"
+                alt="GoDee: Safari Browser Top Bar White."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :borderRadius="false"
+                :width="1026"
+                :height="16.45"
+                :backgroundColor="true"
+              />
+              <img src="../../assets/img/Cases/godee/jpg/trip-request-map.jpg" class="case_img" alt="Trip Request Map" loading="lazy" width="1028" height="483.81">
+            </div>
+            <div class="case_video-flex-wrapper" v-else>
+              <Picture 
+                pictureFolder="common"
+                fileName="safari-top-bar-white"
+                fileExtension="jpg"
+                alt="GoDee: Safari Browser Top Bar White."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :borderRadius="false"
+                :width="1026"
+                :height="16.45"
+                :backgroundColor="true"
+              />
+              <video
+                id="trip-request-map" 
+                class="case_html-video case_trip-request-video" 
+                width="100%" 
+                height="100%" 
+                loop="true"
+                muted="true"
+              >
+                <source :src="getPathTripRequestMapVideo" type="video/mp4">
+                Your browser does not support the video tag.
+              </video>
+            </div>
+          </div>
         </section>
-      </section>
-      <section class="container_full case_infrastructure-scheme-wrapper background-color-silver m-48_bottom media-m-24_bottom">
-        <section class="container_middle">
-          <h2 class="case_title_h2 m-24_bottom case_text-align-center">Infrastructure scheme</h2>
-          <img src="../../assets/img/Cases/godee/gif/infrastructure-scheme.gif" class="case_gif case_infrastructure-scheme-gif" alt="GoDee Mobile App Infrastructure Scheme." loading="lazy" width="645" height="774.92">
+        <section class="container_regular">
+          <h3 class="case_title_h3 m-12_bottom">Trips Monitor</h3>
+          <TextParagraph>
+            The Trips Monitor feature enables operators to track every bus in real time and collect data on late or early arrivals. More importantly, the operator can contact drivers or passengers quickly if necessary.
+          </TextParagraph>
         </section>
-      </section>
-      <section class="container_regular">
-        <TextParagraph class="m-24_bottom media-m-12_bottom">
-          The infrastructure is hosted on the Digital Ocean developer cloud. 
-        </TextParagraph>
-        <TextParagraph class="m-24_bottom media-m-12_bottom">
-          Our applications send requests to the Nginx server, and then they are processed via the gRPC framework and each application is addressed to separate APIs. These APIs refer to Redis quick-caching Streams and the Georeferencing service, which allows bus drivers to be on track along their routes.
-        </TextParagraph>
-        <TextParagraph class="m-72_bottom media-m-48_bottom">
-          Then all information, collected and processed by these services, is controlled via the Web Admin panel, which is connected to the PostgreSQL database, OSRM, Firebase and push notification services. We use Docker containers throughout the development process.
-        </TextParagraph>
-        <h3 class="case_title_h3 m-24_bottom media-m-12_bottom">Technology stack</h3>
-        <ListTechnologies class="m-96_bottom media-m-48_bottom case_list-technologies-godee">
-          <ListTechnologiesItem
-            v-for="(technologiesItem, i) in technologiesList"
-            :key="i"
-            :techName="technologiesItem.techName"
-            :className="technologiesItem.className"
+        <section class="container_middle m-48_top media-m-24_top m-48_bottom media-m-24_bottom">
+          <div class="case_html-video-wrapper case_box-shadow">
+            <div class="case_video-flex-wrapper" v-if="isIphone">
+              <Picture 
+                pictureFolder="common"
+                fileName="safari-top-bar-white"
+                fileExtension="jpg"
+                alt="GoDee: Safari Browser Top Bar White."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :borderRadius="false"
+                :width="1026"
+                :height="16.45"
+                :backgroundColor="true"
+              />
+              <img src="../../assets/img/Cases/godee/jpg/trip-monitor.jpg" class="case_img" alt="Trip Monitor" loading="lazy" width="1028" height="483.81">
+            </div>
+            <div class="case_video-flex-wrapper" v-else>
+              <Picture 
+                pictureFolder="common"
+                fileName="safari-top-bar-white"
+                fileExtension="jpg"
+                alt="GoDee: Safari Browser Top Bar White."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :borderRadius="false"
+                :width="1026"
+                :height="16.45"
+                :backgroundColor="true"
+              />
+              <video 
+                id="trip-monitor"
+                class="case_html-video"
+                width="100%"
+                height="100%"
+                loop="true"
+                muted="true"
+              >
+                <source :src="getPathTripMonitorVideo" type="video/mp4">
+                Your browser does not support the video tag.
+              </video>
+            </div>
+          </div>
+        </section>
+        <section class="container_regular">
+          <TextParagraph class="m-12_bottom">
+            The Trips Monitor dashboard displays the following information:
+          </TextParagraph>
+          <ListNumberedBox class="m-96_bottom media-m-48_bottom">
+            <ListNumberedItemBox>
+              Drivers' locations on mini map in real-time
+            </ListNumberedItemBox>
+            <ListNumberedItemBox>
+              Late and early departures of buses
+            </ListNumberedItemBox>
+            <ListNumberedItemBox>
+              Complete bus schedule weeks in advance
+            </ListNumberedItemBox>
+            <ListNumberedItemBox>
+              Notice to driver that a GoDee client has not been picked up at a bus stop
+            </ListNumberedItemBox>
+            <ListNumberedItemBox>
+              Number of passengers assigned to each stop and driver
+            </ListNumberedItemBox>
+            <ListNumberedItemBox>
+              Historical information through filters
+            </ListNumberedItemBox>
+          </ListNumberedBox>
+          <h3 class="case_title_h3">Route optimization</h3>
+        </section>
+        <section class="container_middle m-24_top media-m-12_top m-48_bottom media-m-24_bottom">
+          <div class="case_html-video-wrapper case_box-shadow">
+            <div class="case_video-flex-wrapper" v-if="isIphone">
+              <Picture 
+                pictureFolder="common"
+                fileName="safari-top-bar-white"
+                fileExtension="jpg"
+                alt="GoDee: Safari Browser Top Bar White."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :borderRadius="false"
+                :width="1026"
+                :height="16.45"
+                :backgroundColor="true"
+              />
+              <img src="../../assets/img/Cases/godee/jpg/route-optimization.jpg" class="case_img" alt="Route Optimization" loading="lazy" width="1028" height="483.81">
+            </div>
+            <div class="case_video-flex-wrapper" v-else>
+              <Picture 
+                pictureFolder="common"
+                fileName="safari-top-bar-white"
+                fileExtension="jpg"
+                alt="GoDee: Safari Browser Top Bar White."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :borderRadius="false"
+                :width="1026"
+                :height="16.45"
+                :backgroundColor="true"
+              />
+              <video 
+                id="route-optimization" 
+                class="case_html-video" 
+                width="100%" 
+                height="100%" 
+                loop="true" 
+                muted="true"
+              >
+                <source :src="getPathRouteOptimizationVideo" type="video/mp4">
+                Your browser does not support the video tag.
+              </video>
+            </div>
+          </div>
+        </section>
+        <section class="container_regular">
+          <TextParagraph>
+            With the help of detailed drivers' performance data, Mad Devs’ Pifia microservice enables route managers to optimize ETA (estimated time of arrival). Pifia shows more accurate arrival and departure times with just one click.
+          </TextParagraph>
+          <TextQuoteBox class="m-48_top m-96_bottom media-m-24_top media-m-72_bottom m-auto">
+            <span class="case_text-quote-break m-24_bottom media-m-12_bottom">Examples of early and late departure times:</span>
+            <span>If Pifia determines that a minibus is usually late due to increased traffic at 5:35 pm and not 5:30 pm, it alerts the route manager to shift the arrival time to 5:35 pm. Five minutes might sound minor, but these small optimizations add up.</span>
+          </TextQuoteBox>
+        </section>
+        <section class="container_full p-104_top p-100_bottom media-p-41_top media-p-24_bottom background-color-black-godee">
+          <section class="container_regular case_real-time-eta">
+            <div class="case_real-time-eta-text-content">
+              <h2 class="case_title_h2 m-24_bottom media-m-8_bottom case_real-time-eta-title">Real-time ETA</h2>
+              <TextParagraph class="m-24_bottom media-m-12_bottom" color="#a0a0a1">
+                In addition, Pifia shows in real time the approximate late/early departures.
+              </TextParagraph>
+              <TextParagraph class="m-24_bottom media-m-12_bottom" color="#a0a0a1">
+                Thus passengers who are waiting for the ride always know whether the bus is coming late and how long it will take.
+              </TextParagraph>
+              <TextParagraph color="#a0a0a1">
+                The information is displayed on their mobile application.
+              </TextParagraph>
+            </div>
+            <div class="case_phone-wrapper-eta-section">
+              <Picture 
+                pictureFolder="godee"
+                fileName="real-time-eta-phone"
+                fileExtension="png"
+                alt="GoDee: Bus Transit App in Vietnam."
+                :boxShadow="false"
+                :lazyLoading="true"
+                :width="358.96"
+                :height="694.62"
+                :backgroundColor="false"
+              />
+            </div>
+          </section>
+        </section>
+        <section class="container_full case_infrastructure-scheme-wrapper background-color-silver m-48_bottom media-m-24_bottom">
+          <section class="container_middle">
+            <h2 class="case_title_h2 m-24_bottom case_text-align-center">Infrastructure scheme</h2>
+            <img src="../../assets/img/Cases/godee/gif/infrastructure-scheme.gif" class="case_gif case_infrastructure-scheme-gif" alt="GoDee Mobile App Infrastructure Scheme." loading="lazy" width="645" height="774.92">
+          </section>
+        </section>
+        <section class="container_regular">
+          <TextParagraph class="m-24_bottom media-m-12_bottom">
+            The infrastructure is hosted on the Digital Ocean developer cloud. 
+          </TextParagraph>
+          <TextParagraph class="m-24_bottom media-m-12_bottom">
+            Our applications send requests to the Nginx server, and then they are processed via the gRPC framework and each application is addressed to separate APIs. These APIs refer to Redis quick-caching Streams and the Georeferencing service, which allows bus drivers to be on track along their routes.
+          </TextParagraph>
+          <TextParagraph class="m-72_bottom media-m-48_bottom">
+            Then all information, collected and processed by these services, is controlled via the Web Admin panel, which is connected to the PostgreSQL database, OSRM, Firebase and push notification services. We use Docker containers throughout the development process.
+          </TextParagraph>
+          <h3 class="case_title_h3 m-24_bottom media-m-12_bottom">Technology stack</h3>
+          <ListTechnologies class="m-96_bottom media-m-48_bottom case_list-technologies-godee">
+            <ListTechnologiesItem
+              v-for="(technologiesItem, i) in technologiesList"
+              :key="i"
+              :techName="technologiesItem.techName"
+              :className="technologiesItem.className"
+            />
+          </ListTechnologies>
+        </section>
+        <section class="container_regular">
+          <h2 class="case_title_h2 m-12_bottom">Monitoring</h2>
+          <TextParagraph class="m-48_bottom media-m-12_bottom" > <!-- Выставить оступы на мобиле -->
+            We believe that every production system requires proper monitoring. For this purpose, we use the Datadog service, which allows us to discover possible issues before they affect our users.
+          </TextParagraph>
+          <p class="m-12_bottom case_monitoring-section-bold">
+            Here is an example of our monitoring configuration for the GoDee project:
+          </p>
+        </section>
+        <section class="container_middle m-96_bottom media-m-48_bottom">
+          <Picture 
+            pictureFolder="godee"
+            fileName="datadog"
+            fileExtension="jpg"
+            alt="GoDee: Monitoring Configuration for Transportation App."
+            :boxShadow="true"
+            :lazyLoading="true"
+            :width="1028"
+            :height="463"
+            :backgroundColor="true"
           />
-        </ListTechnologies>
-      </section>
-      <section class="container_regular">
-        <h2 class="case_title_h2 m-12_bottom">Monitoring</h2>
-        <TextParagraph class="m-48_bottom media-m-12_bottom" > <!-- Выставить оступы на мобиле -->
-          We believe that every production system requires proper monitoring. For this purpose, we use the Datadog service, which allows us to discover possible issues before they affect our users.
-        </TextParagraph>
-        <p class="m-12_bottom case_monitoring-section-bold">
-          Here is an example of our monitoring configuration for the GoDee project:
-        </p>
-      </section>
-      <section class="container_middle m-96_bottom media-m-48_bottom">
-        <Picture 
-          pictureFolder="godee"
-          fileName="datadog"
-          fileExtension="jpg"
-          alt="GoDee: Monitoring Configuration for Transportation App."
-          :boxShadow="true"
-          :lazyLoading="true"
-          :width="1028"
-          :height="463"
-          :backgroundColor="true"
-        />
-      </section>
-      <section class="container_regular">
-        <h2 class="case_title_h2 m-12_bottom">Stable & Scalable solution</h2>
-        <TextParagraph class="m-24_bottom media-m-12_bottom">
-          Transportation and logistics software has zero tolerance to downtime. Imagine hundreds of passengers not being able to book their tickets, drivers not knowing where to pick up/drop off passengers or operators seeing empty screens. 
-        </TextParagraph>
-        <TextParagraph class="m-72_bottom media-m-48_bottom">
-          GoDee’s microservice architecture and the quality of the solution make it easy for each Mad Devs developer to deploy new features without causing spikes in downtime. On top of this, 75% of code is covered by various tests and has detailed documentation and pull requests. GoDee's business model greatly benefits from economies of scale. Thus, increased demand from Ho Chi Minh citizens is backed up by GoDee's unchanging low cost for infrastructure.
-        </TextParagraph>
-        <h2 class="case_title_h2 m-12_bottom">Impact</h2>
-        <TextParagraph class="m-24_bottom">
-          GoDee faced the challenge of changing people’s habits. To grow the user base, we needed to create an extremely helpful and hassle-free solution that offers an alternative to expensive taxis and inconvenient motorbikes. It was also key that it be predictable, affordable and ‘green’ by design.
-        </TextParagraph>
-        <Card class="background-color-orange m-118_bottom media-m-48_bottom">
-          <CardGoDeeImpact />
-        </Card>
-      </section>
-      <section class="container_regular m-72_bottom media-m-48_bottom">
-        <h2 class="case_title_h2 m-48_bottom media-m-24_bottom">Meet the team</h2>
-        <ListTeam class="m-72_bottom media-m-48_bottom">
-          <ListTeamItem
-            v-for="(teamMember, i) in team"
-            :key="i"
-            :name="teamMember.name"
-            :position="teamMember.position"
-            :fileName="teamMember.fileName"
-            :fileNameRetina="`${teamMember.fileName}@2x`"
-            :fileExtension="teamMember.fileExtension"
-            :alt="teamMember.name"
-            pictureFolder="common"
-          />
-        </ListTeam>
-        <TextQuoteAuthor
-          class="case_text-align-center m-72_bottom p-48_top media-m-48_bottom"
-          authorName="Ruslan Karabukaev"
-          authorPosition="Co-founder of GoDee"
-          fileName="ruslan-karabukaev"
-          fileExtension="png"
-          alt="Ruslan Karabukaev"
-          pictureFolder="godee"
-        >
-          We built the platforms from scratch with the Mad Devs team, who dedicatedly supported and guided us to take proper action on several ideas and requirements. We have attracted 27,000 users so far, thanks to their continuous support for improvement and development.
-        </TextQuoteAuthor>
-      </section>
+        </section>
+        <section class="container_regular">
+          <h2 class="case_title_h2 m-12_bottom">Stable & Scalable solution</h2>
+          <TextParagraph class="m-24_bottom media-m-12_bottom">
+            Transportation and logistics software has zero tolerance to downtime. Imagine hundreds of passengers not being able to book their tickets, drivers not knowing where to pick up/drop off passengers or operators seeing empty screens. 
+          </TextParagraph>
+          <TextParagraph class="m-72_bottom media-m-48_bottom">
+            GoDee’s microservice architecture and the quality of the solution make it easy for each Mad Devs developer to deploy new features without causing spikes in downtime. On top of this, 75% of code is covered by various tests and has detailed documentation and pull requests. GoDee's business model greatly benefits from economies of scale. Thus, increased demand from Ho Chi Minh citizens is backed up by GoDee's unchanging low cost for infrastructure.
+          </TextParagraph>
+          <h2 class="case_title_h2 m-12_bottom">Impact</h2>
+          <TextParagraph class="m-24_bottom">
+            GoDee faced the challenge of changing people’s habits. To grow the user base, we needed to create an extremely helpful and hassle-free solution that offers an alternative to expensive taxis and inconvenient motorbikes. It was also key that it be predictable, affordable and ‘green’ by design.
+          </TextParagraph>
+          <Card class="background-color-orange m-118_bottom media-m-48_bottom">
+            <CardGoDeeImpact />
+          </Card>
+        </section>
+        <section class="container_regular m-72_bottom media-m-48_bottom">
+          <h2 class="case_title_h2 m-48_bottom media-m-24_bottom">Meet the team</h2>
+          <ListTeam class="m-72_bottom media-m-48_bottom">
+            <ListTeamItem
+              v-for="(teamMember, i) in team"
+              :key="i"
+              :name="teamMember.name"
+              :position="teamMember.position"
+              :fileName="teamMember.fileName"
+              :fileNameRetina="`${teamMember.fileName}@2x`"
+              :fileExtension="teamMember.fileExtension"
+              :alt="teamMember.name"
+              pictureFolder="common"
+            />
+          </ListTeam>
+          <TextQuoteAuthor
+            class="case_text-align-center m-72_bottom p-48_top media-m-48_bottom"
+            authorName="Ruslan Karabukaev"
+            authorPosition="Co-founder of GoDee"
+            fileName="ruslan-karabukaev"
+            fileExtension="png"
+            alt="Ruslan Karabukaev"
+            pictureFolder="godee"
+          >
+            We built the platforms from scratch with the Mad Devs team, who dedicatedly supported and guided us to take proper action on several ideas and requirements. We have attracted 27,000 users so far, thanks to their continuous support for improvement and development.
+          </TextQuoteAuthor>
+        </section>
+      </div>
       <Footer link="/case-studies/namba-food/" className="godee-case">
         <div class="case_logotype" slot="icon"></div>
         Namba Food <br> Top Delivery Service in <br class="case_mobile-screen-break"> Central Asia

--- a/client/pages/case-studies/godee.vue
+++ b/client/pages/case-studies/godee.vue
@@ -796,7 +796,6 @@ export default {
         'route-optimization'
       ],
       translateY: null,
-      isSafari: false,
       isIphone: false,
       scrollSpeed: 5,
       cardsContainerHeight: null,
@@ -841,12 +840,6 @@ export default {
         this.setDefaultStylesForCards();
       }
     });
-
-    if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) { // Проверяем какой сейчас браузер чтобы на основе этих данных отрисовываем блок
-      this.isSafari = true;
-    } else {
-      this.isSafari = false;
-    }
 
     if(navigator.userAgent.match(/(iPhone)/i)) {
       this.isIphone = true;

--- a/client/pages/case-studies/godee.vue
+++ b/client/pages/case-studies/godee.vue
@@ -2,16 +2,16 @@
   <div class="case_root">
     <HeaderMain />
     <main class="case case_parallax" id="case-scroll-container" ref="main">
-      <div class="case_content-layer p-48_bottom media-p-24_bottom">
-        <CaseHeader logo="godee" videoName="godee-case-main-video.mp4">
-          <h1 class="case_header-title" slot="title">Convenient shuttle <br> bus service</h1>
-          <p class="case_header-description" slot="description">
-            Mad Devs helped GoDee with developing feature-rich software to re-invent <br> public mobility by building new smart ways of a daily commute.
-          </p>
-        </CaseHeader>
-        <div class="case_animation_block" id="case-first-section"></div>
+      <CaseHeader logo="godee" videoName="godee-case-main-video.mp4">
+        <h1 class="case_header-title" slot="title">Convenient shuttle <br> bus service</h1>
+        <p class="case_header-description" slot="description">
+          Mad Devs helped GoDee with developing feature-rich software to re-invent <br> public mobility by building new smart ways of a daily commute.
+        </p>
+      </CaseHeader>
+      <div class="case_content-layer p-48_bottom media-p-24_bottom p-48_top media-p-24_top" id="case-first-section">
+        <div class="case_animation_block"></div>
         <section class="container_regular">
-          <TextParagraph class="m-48_top media-m-24_top">
+          <TextParagraph>
             GoDee is a reliable way to commute in Ho Chi Minh City, Vietnam. Its shuttle buses take express routes that link the city’s major districts and popular destinations. GoDee helps riders save time, money and the planet due to its lower ecological impact.
           </TextParagraph>
           <TextQuote class="m-auto m-96_top m-96_bottom media-m-48_top media-m-48_bottom">


### PR DESCRIPTION
В Safari не работал parallax эффект,  потому что он реализован через css 3d трансформацию и у секции был установлен `overflow: hidden; `. <br />
`overflow: hidden` переопределяет свойства 3d трансформации в Safari и она перестаёт работать ( parallax эффекта нет ). <br />
Можно вот тут почитать:

- [Don't set overflow: hidden on elements with 3D transformed children](https://codepen.io/thebabydino/details/rACbl)
- https://htmlacademy.ru/blog/boost/tutorial/pure-css-parallax-websites

<br />
<br />
**Решение:** <br />
Я разрулил эту проблему с помощью настройки расположения слоёв друг над другом. <br />
Все секции с контентом завернул в див с `background: #fff` и обычным `z-index: 1` <br />
А секции с паралаксом дал `z-index: -9`, чтобы она проходила под дивами с контентом