### PR TITLE
MR-2595 Fixed the CU posts page, added the cluter data with postsList

### DIFF
--- a/client/pages/customer-university/_uid.vue
+++ b/client/pages/customer-university/_uid.vue
@@ -138,5 +138,20 @@ export default {
       return { ...this.$data }
     },
   },
+
+  mounted() {
+    this.title = this.$prismic.asText(this.document.meta_title) || this.document.title[0].text
+    this.getClusterData()
+  },
+
+  methods: {
+    getClusterData() {
+      this.$prismic.api.getSingle('cu_master').then(response => {
+        this.cluster =
+          response.data.body.find(cluster => cluster.items.find(post => post.cu_post.id === this.id) !== undefined) ||
+          null
+      })
+    },
+  },
 }
 </script>


### PR DESCRIPTION
При рефакториге в рамках этой мрки https://github.com/maddevsio/maddevs/pull/713 затерли `getClusterData` метод, который доставал список всех CU постов. Этот список юзается:

- В дропдауне,  который в начале CU статьи
- Для навигационных кнопок next & prev post
- Для списка CU постов в конце статьи 

Вернул недостающие данные для поста