### PR TITLE
MAR-146 Fixed problem with horizontal scroll in the post page

### DIFF
--- a/client/components/Blog/PostView.vue
+++ b/client/components/Blog/PostView.vue
@@ -460,6 +460,7 @@ export default {
     &__introduction-paragraph,
     &__text-container {
       padding: 0 24px;
+      word-break: break-word;
     }
 
     &__recommended-posts-list {

--- a/client/components/Blog/slices/TextSlice.vue
+++ b/client/components/Blog/slices/TextSlice.vue
@@ -32,8 +32,6 @@ export default {
 @import '../../../assets/styles/_vars';
 
 .textslice {
-  word-break: break-word;
-
   /deep/ strong,
   /deep/ p,
   /deep/ h1,

--- a/client/components/Blog/slices/TextSlice.vue
+++ b/client/components/Blog/slices/TextSlice.vue
@@ -32,6 +32,8 @@ export default {
 @import '../../../assets/styles/_vars';
 
 .textslice {
+  word-break: break-word;
+
   /deep/ strong,
   /deep/ p,
   /deep/ h1,


### PR DESCRIPTION
Задача - https://maddevs.atlassian.net/browse/MAR-146

**В чём была проблема:**
Некоторые слова в тексте поста были очень длинными и выходили за пределы страницы в бок. Поэтому появлялся горизонтальный скролл.

**Решение:**
Добавил свойство `word-break: break-word` для контенера, который содержит весь контент поста
