### PR TITLE
MAR-245 Fixed the scrollBehavior configuration for hash links

### DIFF
--- a/client/app/router.scrollBehavior.js
+++ b/client/app/router.scrollBehavior.js
@@ -24,6 +24,11 @@ if (process.client) {
 export default async (to, from, savedPosition) => {
   const position = savedPosition || { x: 0, y: 0 }
 
+  // triggerScroll is only fired when a new component is loaded
+  if (to.path === from.path && to.hash !== from.hash) {
+    $nuxt.$nextTick(() => $nuxt.$emit('triggerScroll'))
+  }
+
   const findEl = async (hash, x) => document.querySelector(hash)
       || new Promise(resolve => {
         if (x > 50) resolve()
@@ -34,11 +39,6 @@ export default async (to, from, savedPosition) => {
     const hashEl = await findEl(to.hash)
     if ('scrollBehavior' in document.documentElement.style) return window.scrollTo({ top: hashEl.offsetTop, behavior: 'smooth' })
     return window.scrollTo(0, hashEl.offsetTop)
-  }
-
-  // triggerScroll is only fired when a new component is loaded
-  if (to.path === from.path && to.hash !== from.hash) {
-    $nuxt.$nextTick(() => $nuxt.$emit('triggerScroll'))
   }
 
   return new Promise(resolve => {


### PR DESCRIPTION
1) Якорные ссылки не работали. Поменял scrollBehavior конфигурацию
Решения брал из этих статей:

- https://levelup.gitconnected.com/nuxt-js-custom-scrollbehavior-fired-after-page-loaded-cd94fd6ddd12
- https://zachcardoza.com/post/nuxtjs-smooth-scrolling-with-hash-links/