### PR TITLE
MAR-153 fix problem with lazy for recommended posts

### DIFF
--- a/client/components/Blog/Main/AllPostsSection.vue
+++ b/client/components/Blog/Main/AllPostsSection.vue
@@ -114,13 +114,15 @@ export default {
         postItemEl.scrollIntoView({ block: 'start' })
         window.scrollTo(0, window.scrollY - 120) // scroll for distance between the post and the top of the screen
       }
-
-      // Set lazy for new filtered posts
-      this.$nextTick(() => initializeLazyLoad())
     },
 
     // Set lazy when new posts has been loaded after click on see more button
     postsPage() {
+      this.$nextTick(() => initializeLazyLoad())
+    },
+
+    postsCategory() {
+      // Refresh recommended blog posts and author images
       this.$nextTick(() => initializeLazyLoad())
     },
   },

--- a/client/components/Blog/Main/Main.vue
+++ b/client/components/Blog/Main/Main.vue
@@ -8,11 +8,12 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 import TheLastPostSection from '@/components/Blog/Main/TheLastPostSection'
 import LatestPostsSection from '@/components/Blog/Main/LatestPostsSection'
 import CustomerUniversitySection from '@/components/Blog/Main/CustomerUniversitySection'
 import AllPostsSection from '@/components/Blog/Main/AllPostsSection'
+import initializeLazyLoad from '@/helpers/lazyLoad'
 
 import initLazyLoadMixin from '@/mixins/initLazyLoadMixin'
 
@@ -31,6 +32,19 @@ export default {
     return {
       pageSize: 12,
     }
+  },
+
+  computed: {
+    ...mapGetters([
+      'allPosts',
+    ]),
+  },
+
+  watch: {
+    allPosts() {
+      // Add lazy loading for async posts
+      this.$nextTick(() => initializeLazyLoad())
+    },
   },
 
   created() {

--- a/client/components/Blog/shared/PostAuthor.vue
+++ b/client/components/Blog/shared/PostAuthor.vue
@@ -2,9 +2,9 @@
   <div class="blog-post__author">
     <img
       v-if="document.author_image.url !== undefined"
+      ref="authorImage"
       :data-src="document.author_image.url"
       :alt="$prismic.asText(document.author)"
-      ref="authorImage"
       class="blog-post__author-image img_lazy"
     >
     <div

--- a/client/components/Blog/shared/PostAuthor.vue
+++ b/client/components/Blog/shared/PostAuthor.vue
@@ -4,6 +4,7 @@
       v-if="document.author_image.url !== undefined"
       :data-src="document.author_image.url"
       :alt="$prismic.asText(document.author)"
+      ref="authorImage"
       class="blog-post__author-image img_lazy"
     >
     <div
@@ -34,6 +35,13 @@ export default {
   computed: {
     shortTitle() {
       return this.$prismic.asText(this.document.author).substr(0, 100)
+    },
+  },
+
+  watch: {
+    document() {
+      this.$refs.authorImage.classList.remove('img_lazy-fade')
+      this.$refs.authorImage.classList.add('img_lazy')
     },
   },
 }

--- a/client/components/Blog/shared/RecommendedBlogWidget.vue
+++ b/client/components/Blog/shared/RecommendedBlogWidget.vue
@@ -5,6 +5,7 @@
   >
     <div class="blog-post">
       <img
+        ref="recommendedImage"
         :data-src="post.data.featured_image.url"
         :alt="post.data.featured_image.alt"
         class="blog-post__image img_lazy"
@@ -100,6 +101,14 @@ export default {
       const limit = 45
       const title = this.$prismic.asText(this.post.data.title)
       return textEllipsis(title, { limit })
+    },
+  },
+
+  // Refresh class names for image when post has been updated
+  watch: {
+    post() {
+      this.$refs.recommendedImage.classList.remove('img_lazy-fade')
+      this.$refs.recommendedImage.classList.add('img_lazy')
     },
   },
 }


### PR DESCRIPTION
1. Добавил новые watch в компонент AllPostsSection.vue, он отрабатывает как только изменится значение postsCategory переменной, это позволяет добавить lazy для новые постов которые появились после фильтрации
2. Добавил новые watch в компонент Main.vue, он отвечает за навешивание lazy loading для асинхронно подгружаемых блог постов, рядом используемый миксин не может хендлить асинхронные посты и поэтому пришлось добавить этот фикс
3. Добавил фикс который решает проблему с обновлением картинок у фильтрованных постов. Фикс работает следующим образом. Вотчер смотрит на пропсы компонента, если те изменили, то он выставляет актуальный класс для картинки и скрипт который добавляет lazy loading отрабатывает корректно

P.s сами фиксы получились костыльными, но чтобы реализовать логику лучше, нужно рефакторить половину кода в блоге. 