### PR TITLE
MAR-752 fix animation bug in GoDee case

### DIFF
--- a/client/components/Cases/godee/cards/CardGoDeeFeature.vue
+++ b/client/components/Cases/godee/cards/CardGoDeeFeature.vue
@@ -4,6 +4,8 @@
       v-if="iconName"
       :data-src="require(`@/assets/img/Studies/svg/${iconName}.svg`)"
       :alt="iconName"
+      width="51.94"
+      height="51.94"
       class="card-content_icon img_lazy"
     >
     <h4 class="case_title_h4 card-content_title">
@@ -41,6 +43,7 @@ export default {
   &_icon {
     width: 51.94px;
     height: 51.94px;
+    display: block;
     margin-bottom: 13px;
   }
 

--- a/tests/components/Cases/godee/__snapshots__/DevelopmentGoals.spec.js.snap
+++ b/tests/components/Cases/godee/__snapshots__/DevelopmentGoals.spec.js.snap
@@ -32,6 +32,8 @@ exports[`DevelopmentGoals component should render correctly 1`] = `
               alt="gps"
               class="card-content_icon img_lazy"
               data-src="[object Object]"
+              height="51.94"
+              width="51.94"
             />
              
             <h4
@@ -61,6 +63,8 @@ exports[`DevelopmentGoals component should render correctly 1`] = `
               alt="payment-method"
               class="card-content_icon img_lazy"
               data-src="[object Object]"
+              height="51.94"
+              width="51.94"
             />
              
             <h4
@@ -102,6 +106,8 @@ exports[`DevelopmentGoals component should render correctly 1`] = `
               alt="live-location-tacking"
               class="card-content_icon img_lazy"
               data-src="[object Object]"
+              height="51.94"
+              width="51.94"
             />
              
             <h4
@@ -131,6 +137,8 @@ exports[`DevelopmentGoals component should render correctly 1`] = `
               alt="referrals"
               class="card-content_icon img_lazy"
               data-src="[object Object]"
+              height="51.94"
+              width="51.94"
             />
              
             <h4
@@ -160,6 +168,8 @@ exports[`DevelopmentGoals component should render correctly 1`] = `
               alt="possible-routes"
               class="card-content_icon img_lazy"
               data-src="[object Object]"
+              height="51.94"
+              width="51.94"
             />
              
             <h4

--- a/tests/components/Cases/godee/__snapshots__/Main.spec.js.snap
+++ b/tests/components/Cases/godee/__snapshots__/Main.spec.js.snap
@@ -493,6 +493,8 @@ exports[`Main component should render correctly 1`] = `
                 alt="live-chat"
                 class="card-content_icon img_lazy"
                 data-src="[object Object]"
+                height="51.94"
+                width="51.94"
               />
                
               <h4
@@ -524,6 +526,8 @@ exports[`Main component should render correctly 1`] = `
                 alt="trip-request"
                 class="card-content_icon img_lazy"
                 data-src="[object Object]"
+                height="51.94"
+                width="51.94"
               />
                
               <h4
@@ -630,6 +634,8 @@ exports[`Main component should render correctly 1`] = `
                   alt="gps"
                   class="card-content_icon img_lazy"
                   data-src="[object Object]"
+                  height="51.94"
+                  width="51.94"
                 />
                  
                 <h4
@@ -659,6 +665,8 @@ exports[`Main component should render correctly 1`] = `
                   alt="payment-method"
                   class="card-content_icon img_lazy"
                   data-src="[object Object]"
+                  height="51.94"
+                  width="51.94"
                 />
                  
                 <h4
@@ -700,6 +708,8 @@ exports[`Main component should render correctly 1`] = `
                   alt="live-location-tacking"
                   class="card-content_icon img_lazy"
                   data-src="[object Object]"
+                  height="51.94"
+                  width="51.94"
                 />
                  
                 <h4
@@ -729,6 +739,8 @@ exports[`Main component should render correctly 1`] = `
                   alt="referrals"
                   class="card-content_icon img_lazy"
                   data-src="[object Object]"
+                  height="51.94"
+                  width="51.94"
                 />
                  
                 <h4
@@ -758,6 +770,8 @@ exports[`Main component should render correctly 1`] = `
                   alt="possible-routes"
                   class="card-content_icon img_lazy"
                   data-src="[object Object]"
+                  height="51.94"
+                  width="51.94"
                 />
                  
                 <h4

--- a/tests/components/Cases/godee/__snapshots__/Mvp.spec.js.snap
+++ b/tests/components/Cases/godee/__snapshots__/Mvp.spec.js.snap
@@ -56,6 +56,8 @@ exports[`Mvp component should render correctly 1`] = `
             alt="live-chat"
             class="card-content_icon img_lazy"
             data-src="[object Object]"
+            height="51.94"
+            width="51.94"
           />
            
           <h4
@@ -87,6 +89,8 @@ exports[`Mvp component should render correctly 1`] = `
             alt="trip-request"
             class="card-content_icon img_lazy"
             data-src="[object Object]"
+            height="51.94"
+            width="51.94"
           />
            
           <h4


### PR DESCRIPTION
Исправил баг с анимацией карточек в кейсе GoDee

Причина бага:
Проблема была с lazy loading логикой, на момент загрузки страницы y иконок не выставлялась дефолтная высота и ширина, из-за этого все расчеты высоты секции с карточками в скриптах были не правильными, я поправил эту проблему и анимация заработала одинаково во всех браузерах. 