### PR TITLE
MAR-814 Fixed display of pictures for scenarios cards in the Namba Food case ( bug in Safari browser )

### DIFF
--- a/client/components/Cases/nambafood/cards/CardUseCase.vue
+++ b/client/components/Cases/nambafood/cards/CardUseCase.vue
@@ -111,6 +111,7 @@ export default {
     grid-template-columns: repeat(2, 1fr);
     height: 100%;
     margin-bottom: -32px;
+    max-height: 192px;
   }
 
   &__title {


### PR DESCRIPTION
Поправил ототражение картинок в карточках из секции "Typical usage scenarios and user roles" в Namba Food кейсе. Картинки не отображались в Safari браузере