### PR TITLE
MAR-806 Corrected sizes of introduction image in the PostView page, added lazy loading for this image

### DIFF
--- a/client/components/Blog/header/Common.vue
+++ b/client/components/Blog/header/Common.vue
@@ -59,7 +59,7 @@ export default {
 
     coverImageHeight: {
       type: Number,
-      default: 533,
+      default: 534,
     },
   },
 

--- a/client/components/Blog/header/Common.vue
+++ b/client/components/Blog/header/Common.vue
@@ -8,15 +8,20 @@
       {{ subtitle }}
     </p>
     <slot name="afterTitle" />
-    <img
+    <div
       v-if="coverImageUrl"
-      :src="coverImageUrl"
-      :class="getImageClass"
-      :alt="coverImageAltText"
-      :width="coverImageWidth"
-      :height="coverImageHeight"
       class="blog-post__introduction-image"
+      :class="imageBackgroundClass"
     >
+      <img
+        :data-src="coverImageUrl"
+        :data-srcset="[imageWithoutCrop + ' 2x']"
+        :width="coverImageWidth"
+        :height="coverImageHeight"
+        :alt="coverImageAltText"
+        class="img_lazy"
+      >
+    </div>
   </div>
 </template>
 
@@ -49,7 +54,7 @@ export default {
 
     coverImageWidth: {
       type: Number,
-      default: 982,
+      default: 983,
     },
 
     coverImageHeight: {
@@ -59,7 +64,11 @@ export default {
   },
 
   computed: {
-    getImageClass() {
+    imageWithoutCrop() {
+      return this.coverImageUrl.split('?auto')[0] // get image witout crop for retina display
+    },
+
+    imageBackgroundClass() {
       const allowedExtensions = ['jpeg', 'jpg']
       const extension = extractFileExtension(this.coverImageUrl)
       return allowedExtensions.includes(extension) ? 'blog-post__introduction-image--with-background' : ''
@@ -91,12 +100,16 @@ export default {
   }
 
   &__introduction-image {
-    width: 120%;
-    margin-left: -10%;
-    height: auto;
-    vertical-align: middle;
+    width: 983px;
+    margin-left: -82.5px;
     &--with-background {
       background-color: $bgcolor--silver;
+    }
+    img {
+      width: 100%;
+      height: auto;
+      display: block;
+      vertical-align: middle;
     }
   }
 }
@@ -122,7 +135,9 @@ export default {
     &__introduction-image {
       width: 100%;
       margin: 0;
-      vertical-align: bottom;
+      img {
+        vertical-align: bottom;
+      }
     }
   }
 }

--- a/client/components/Blog/header/CustomerUniversity.vue
+++ b/client/components/Blog/header/CustomerUniversity.vue
@@ -4,6 +4,8 @@
     :subtitle="subtitle"
     :cover-image-url="featuredImage.url"
     :cover-image-alt-text="featuredImage.alt"
+    :cover-image-width="featuredImage.dimensions.width"
+    :cover-image-height="featuredImage.dimensions.height"
   >
     <template #beforeTitle>
       <div class="row cluster-navigation">

--- a/tests/components/Blog/header/__snapshots__/Blog.spec.js.snap
+++ b/tests/components/Blog/header/__snapshots__/Blog.spec.js.snap
@@ -55,13 +55,18 @@ exports[`header Blog is a Vue instance 1`] = `
       </div>
     </div>
      
-    <img
-      alt="alt"
+    <div
       class="blog-post__introduction-image"
-      height="300"
-      src="url"
-      width="200"
-    />
+    >
+      <img
+        alt="alt"
+        class="img_lazy"
+        data-src="url"
+        data-srcset="url 2x"
+        height="300"
+        width="200"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/tests/components/Blog/header/__snapshots__/Common.spec.js.snap
+++ b/tests/components/Blog/header/__snapshots__/Common.spec.js.snap
@@ -22,13 +22,18 @@ exports[`header Common is a Vue instance 1`] = `
   
     </p>
       
-    <img
-      alt=""
+    <div
       class="blog-post__introduction-image blog-post__introduction-image--with-background"
-      height="533"
-      src="some-url.jpg"
-      width="982"
-    />
+    >
+      <img
+        alt=""
+        class="img_lazy"
+        data-src="some-url.jpg"
+        data-srcset="some-url.jpg 2x"
+        height="533"
+        width="983"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/tests/components/Blog/header/__snapshots__/Common.spec.js.snap
+++ b/tests/components/Blog/header/__snapshots__/Common.spec.js.snap
@@ -30,7 +30,7 @@ exports[`header Common is a Vue instance 1`] = `
         class="img_lazy"
         data-src="some-url.jpg"
         data-srcset="some-url.jpg 2x"
-        height="533"
+        height="534"
         width="983"
       />
     </div>

--- a/tests/components/Blog/header/__snapshots__/CustomerUniversity.spec.js.snap
+++ b/tests/components/Blog/header/__snapshots__/CustomerUniversity.spec.js.snap
@@ -3,9 +3,9 @@
 exports[`customer university header component should render correctly with default props 1`] = `
 <div>
   <commonheader-stub
-    coverimageheight="533"
+    coverimageheight="452"
     coverimageurl="https://images.prismic.io/superpupertest/82f90d05-8c22-49c1-bf1e-8721a0e3eda6_Constructing+a+Map+in+the+Mercator+Projection+for+Android.png?auto=compress,format"
-    coverimagewidth="982"
+    coverimagewidth="780"
     subtitle="[object Object]"
     title="[object Object]"
   >


### PR DESCRIPTION
Задача - https://maddevs.atlassian.net/browse/MAR-806

**Проблема:**
Заглавная картинка блога была мыльной.

**Решение:**

- Поправил стили для отображения заглавной картинки
- Для retina дисплеев нужна картинка с x2 размером, т.е 983px x 2 = 1966px по ширине минимум. У нас картинки с размерами 2000px по ширине.  Поэтому оригинальный размер как раз подходит. Добавил `srcset` аттрибут для retina дисплеев, в котором выводится картинка в полном размере без кропа
