### PR TITLE
MAR-846 added trailing slash for blog pages url

### DIFF
--- a/client/mixins/buildPostPageMixin.js
+++ b/client/mixins/buildPostPageMixin.js
@@ -6,11 +6,11 @@ const buildPostPageMixin = (pageName = 'blog', postType = 'post') => ({
     $prismic, store, params, error,
   }) {
     let schemaOrgSnippet = ''
-    let openGraphUrl = `${process.env.domain}/blog/${params.uid}`
+    let openGraphUrl = `${process.env.domain}/blog/${params.uid}/`
 
     // Open graph url
-    if (pageName === 'author' || pageName === 'tag') openGraphUrl = `${process.env.domain}/blog/${pageName}/${params.uid}/${params.postUID}`
-    if (pageName === 'customer-university') openGraphUrl = `${process.env.domain}/customer-university/${params.uid}`
+    if (pageName === 'author' || pageName === 'tag') openGraphUrl = `${process.env.domain}/blog/${pageName}/${params.uid}/${params.postUID}/`
+    if (pageName === 'customer-university') openGraphUrl = `${process.env.domain}/customer-university/${params.uid}/`
 
     try {
       const post = await store.dispatch('getBlogPost', { type: postType, uid: (params.postUID || params.uid) })


### PR DESCRIPTION
*  Исправил недочет из-за которого показатели Health score упали на 42%. Был добавлен конечный слеш для всех ссылок на статьи в блоге. Видимо при переносе забыли добавить конечный слеш, так как это не самый очевидный кейс в коде. 

* Чтобы в дальнейшем такого не повторилось, я поговорил с Денисом и предложил ему добавить в тесты для SEO проверку на наличие конечного слеша у URL.
