### PR TITLE
MAR-874 fix minor bugs in markup

### DIFF
--- a/client/components/Cases/sjmc/HardwareVideo.vue
+++ b/client/components/Cases/sjmc/HardwareVideo.vue
@@ -24,7 +24,7 @@
         ref="video"
         data-testid="test-case_video"
         width="100%"
-        :height="884"
+        height="100%"
         muted
         playsinline
         loop

--- a/client/components/core/forms/FooterForm.vue
+++ b/client/components/core/forms/FooterForm.vue
@@ -133,6 +133,10 @@ export default {
       color: $text-color--grey-pale;
     }
 
+    &::-moz-placeholder {
+      opacity: 1;
+    }
+
     &.textarea {
       font-size: 16px;
       line-height: 24px;

--- a/tests/__snapshots__/caseSJMC.spec.js.snap
+++ b/tests/__snapshots__/caseSJMC.spec.js.snap
@@ -901,7 +901,7 @@ exports[`sirJohnMonashCentre renders correctly 1`] = `
               <video
                 class="media_lazy"
                 data-testid="test-case_video"
-                height="884"
+                height="100%"
                 id="iphone-video"
                 loop="loop"
                 muted="muted"

--- a/tests/components/Cases/sjmc/__snapshots__/Hardware.spec.js.snap
+++ b/tests/components/Cases/sjmc/__snapshots__/Hardware.spec.js.snap
@@ -314,7 +314,7 @@ exports[`Hardware component should render correctly 1`] = `
           <video
             class="media_lazy"
             data-testid="test-case_video"
-            height="884"
+            height="100%"
             id="iphone-video"
             loop="loop"
             muted="muted"

--- a/tests/components/Cases/sjmc/__snapshots__/HardwareVideo.spec.js.snap
+++ b/tests/components/Cases/sjmc/__snapshots__/HardwareVideo.spec.js.snap
@@ -160,7 +160,7 @@ exports[`HardwareVideo component should render correctly 1`] = `
       <video
         class="media_lazy"
         data-testid="test-case_video"
-        height="884"
+        height="100%"
         id="iphone-video"
         loop="loop"
         muted="muted"


### PR DESCRIPTION
1. Исправил верстку секции с телефоном в кейсу музея, удалил жестко заданную высоту у видео через атрибут так как этот параметр ломал всю верстку 
2. Поправил цвет плейсхолдеров в футере убрав у них прозрачность которую по дефолту добавляет Firefox браузер