### PR TITLE
MAR-955 update logic for vuex action getBlogAuthors

### DIFF
--- a/client/store/modules/blogAuthors.js
+++ b/client/store/modules/blogAuthors.js
@@ -55,7 +55,7 @@ export const mutations = {
 export const actions = {
   async getBlogAuthors({ commit }) {
     const authors = await getBlogAuthors(this.$prismic)
-    commit('SET_ALL_AUTHORS', authors)
+    if (Array.isArray(authors)) commit('SET_ALL_AUTHORS', authors)
   },
   async getBlogAuthor({ commit }, payload) {
     const author = await getBlogAuthor(this.$prismic, payload)

--- a/tests/store/blogAuthors.spec.js
+++ b/tests/store/blogAuthors.spec.js
@@ -7,7 +7,7 @@ import { getBlogAuthors, getBlogAuthor, getAuthorPosts } from '@/api/blogAuthors
 
 jest.mock('@/api/blogAuthors', () => (
   {
-    getBlogAuthors: jest.fn(() => 'test'),
+    getBlogAuthors: jest.fn(() => []),
     getBlogAuthor: jest.fn(() => 'test'),
     getAuthorPosts: jest.fn(() => 'test'),
   }
@@ -137,7 +137,7 @@ describe('BlogAuthors module mutations', () => {
 })
 
 describe('BlogAuthors module actions', () => {
-  it('should correctly called getBlogAuthors', async () => {
+  it('should called commit if api method return array', async () => {
     const store = {
       commit: jest.fn(),
     }
@@ -145,7 +145,18 @@ describe('BlogAuthors module actions', () => {
     await actions.getBlogAuthors(store)
 
     expect(getBlogAuthors).toHaveBeenCalledTimes(1)
-    expect(store.commit).toHaveBeenCalledWith('SET_ALL_AUTHORS', 'test')
+    expect(store.commit).toHaveBeenCalledWith('SET_ALL_AUTHORS', [])
+  })
+
+  it('should not called commit if api method did not return array', async () => {
+    const store = {
+      commit: jest.fn(),
+    }
+    getBlogAuthors.mockReturnValue('test')
+
+    await actions.getBlogAuthors(store)
+
+    expect(store.commit).not.toHaveBeenCalled()
   })
 
   it('should correctly called getBlogAuthor', async () => {

--- a/tests/store/blogAuthors.spec.js
+++ b/tests/store/blogAuthors.spec.js
@@ -152,7 +152,7 @@ describe('BlogAuthors module actions', () => {
     const store = {
       commit: jest.fn(),
     }
-    getBlogAuthors.mockReturnValue('test')
+    getBlogAuthors.mockReturnValue({})
 
     await actions.getBlogAuthors(store)
 


### PR DESCRIPTION
Задача в рамках которой работал: https://maddevs.atlassian.net/browse/MAR-877
1. Добавил условие при котором мутация будет вызываться только в случае если api метод вернет массив и его можно будет перебрать методом map() в мутации. 
2. Модифицировал один из существующих тестов для action функции и добавил один новый который проверяет что будет если api метод вернет не массив а что-то другое

Предположительную причину проблемы описал в задаче которую приложил выше. 