### PR TITLE
MAR-734 Fixed display of video with iPhone in SJMC case

### DIFF
--- a/client/components/Cases/sjmc/Hardware.vue
+++ b/client/components/Cases/sjmc/Hardware.vue
@@ -76,12 +76,7 @@
       </TextParagraph>
     </section>
     <section class="container_full case_sec-container background-color-black-primary">
-      <img
-        v-if="isIphone"
-        :src="$getMediaFromS3('/images/Cases/sjmc/png/bluetooth-beacons-video-background.png')"
-        class="case_img-ios-only"
-      >
-      <HardwareVideo v-else />
+      <HardwareVideo />
     </section>
     <section class="container_regular">
       <p class="case_image-description m-34_top media-m-24_top">
@@ -113,7 +108,6 @@
 import TextParagraph from '@/components/Cases/shared/TextParagraph'
 import Picture from '@/components/Cases/shared/Picture'
 import HardwareVideo from '@/components/Cases/sjmc/HardwareVideo'
-import isIphoneMixin from '@/mixins/isIphoneMixin'
 
 export default {
   name: 'Hardware',
@@ -122,8 +116,6 @@ export default {
     Picture,
     HardwareVideo,
   },
-
-  mixins: [isIphoneMixin],
 }
 </script>
 
@@ -135,18 +127,6 @@ export default {
 
       @media screen and (max-width: 768px) {
         padding: 50px 0;
-      }
-    }
-
-    &_img-ios-only {
-      width: 23%;
-      max-width: 460px;
-      min-width: 225px;
-      display: block;
-      margin: 0 auto;
-
-      @media screen and (max-width: 360px) {
-        min-width: 280px;
       }
     }
   }

--- a/client/components/Cases/sjmc/HardwareVideo.vue
+++ b/client/components/Cases/sjmc/HardwareVideo.vue
@@ -25,6 +25,7 @@
         data-testid="test-case_video"
         width="100%"
         height="100%"
+        :controls="false"
         muted
         playsinline
         loop
@@ -94,6 +95,12 @@ export default {
       width: 23%;
       max-width: 460px;
       min-width: 270px;
+      video {
+        display: block;
+        &::-webkit-media-controls {
+          display:none !important;
+        }
+      }
     }
 
     &_sound-control {


### PR DESCRIPTION
Задача - https://maddevs.atlassian.net/browse/MAR-734

Сейчас на странице кейса музея на iOS устройствах вместо видео с телефоном - просто статичная картинка. По задумке там должен был быть видос который запускается по клику. От видео на время пришлось отказаться так как оно отображалось не правильно, точнее оно вообще не отображался ровно до того момента пока на него не кликнешь. 

В рамках этой задачи нужно исправить баг с отображением и выпилить статичную картинку.

** Изменения:**

- Выпилил картинку
- Поправил стили для видео тега