### PR TITLE
Added ignore config for veeqo case page

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -77,6 +77,10 @@ module.exports = {
     height: '2px',
   },
   components: true,
+  /*
+   ** Component will be ignored in building
+   */
+  ignore: 'pages/case-studies/veeqo.vue',
   generate: {
     async routes() {
       const getPosts = async pageUrl => {


### PR DESCRIPTION
Добавил настройку игнорирования компонента veeqo.vue при сборке проекта, чтобы страница не попала на прод. 

Сделал согласно вот этой документации: https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-ignore#the-ignore-property

Добавил игнорирование в nuxt.config для того чтобы все настройки в проекте были в одном файле