### PR TITLE
MAR-1059 optimize images in blog post pages

### DIFF
--- a/client/components/Blog/shared/PostAuthor.vue
+++ b/client/components/Blog/shared/PostAuthor.vue
@@ -14,6 +14,8 @@
         :data-src="thumbnailImage.url"
         :alt="thumbnailImage.alt"
         class="img_lazy"
+        width="36"
+        height="36"
       >
     </div>
     <div

--- a/client/components/slices/AuthorSlice.vue
+++ b/client/components/slices/AuthorSlice.vue
@@ -6,6 +6,8 @@
     <div class="author-slice__info">
       <div class="author-slice__image">
         <img
+          width="64"
+          height="64"
           :data-src="blogAuthor.image.url"
           :alt="blogAuthor.image.alt"
           class="img_lazy"

--- a/client/components/slices/EmbedSlice.vue
+++ b/client/components/slices/EmbedSlice.vue
@@ -11,10 +11,12 @@
     />
     <template v-if="slice.items[0].embed.type === 'link'">
       <div class="embed__image-wrapper">
-        <div
-          :style="{ backgroundImage: `url(${slice.items[0].embed.thumbnail_url})` }"
-          class="embed__image"
-        />
+        <img
+          width="150"
+          height="126"
+          class="embed__image img_lazy"
+          :data-src="slice.items[0].embed.thumbnail_url"
+        >
       </div>
     </template>
   </div>
@@ -103,9 +105,6 @@ export default {
     a {
       text-decoration: none;
     }
-    img {
-      display: none;
-    }
     h1,
     p {
       letter-spacing: -0.02em;
@@ -137,9 +136,7 @@ export default {
     height: 100%;
     min-width: 136px;
     min-height: 60px;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    object-fit: cover;
 
     &-wrapper {
       width: 33%;

--- a/client/components/slices/ImageAttributesSlice.vue
+++ b/client/components/slices/ImageAttributesSlice.vue
@@ -11,6 +11,8 @@
             class="img_lazy"
             :data-src="img.url"
             :alt="img.alt"
+            width="680"
+            height="170"
           >
         </a>
       </div>
@@ -22,6 +24,8 @@
             class="img_lazy"
             :data-src="img.url"
             :alt="img.alt"
+            width="680"
+            height="170"
           >
         </div>
       </div>

--- a/tests/components/slices/__snapshots__/AuthorSlice.spec.js.snap
+++ b/tests/components/slices/__snapshots__/AuthorSlice.spec.js.snap
@@ -15,6 +15,8 @@ exports[`AuthorSlice component should render correctly 1`] = `
           alt="alt"
           class="img_lazy"
           data-src="someurl"
+          height="64"
+          width="64"
         />
       </div>
        

--- a/tests/components/slices/__snapshots__/ImageAttributesSlice.spec.js.snap
+++ b/tests/components/slices/__snapshots__/ImageAttributesSlice.spec.js.snap
@@ -15,6 +15,8 @@ exports[`image attribute slice component is a Vue instance 1`] = `
           alt="alt text"
           class="img_lazy"
           data-src="https://images.prismic.io/superpupertest/4b27a325-c48e-4f20-943d-e40537291055_2020-12-08_14-11.png?auto=compress,format&rect=0,0,1231,306&w=1200&h=298"
+          height="170"
+          width="680"
         />
       </a>
     </div>

--- a/tests/components/slices/__snapshots__/index.spec.js.snap
+++ b/tests/components/slices/__snapshots__/index.spec.js.snap
@@ -130,6 +130,8 @@ exports[`slice block component should render correctly 1`] = `
               alt="alt text"
               class="img_lazy"
               data-src="https://images.prismic.io/superpupertest/4b27a325-c48e-4f20-943d-e40537291055_2020-12-08_14-11.png?auto=compress,format&rect=0,0,1231,306&w=1200&h=298"
+              height="170"
+              width="680"
             />
           </a>
         </div>


### PR DESCRIPTION
1. Отпимизировал картинки на странице блог постов, чтобы на них не орал PSI(https://developers.google.com/speed/pagespeed/insights/?hl=ru)
2. Выставил дефолтную высоту и ширину картинкам
3. Подключил картинку в Embed блоке через img тег и добавил свойство lazy loading 