### PR TITLE
MAR-1659 added new tests for ModalSearch component

### DIFF
--- a/client/components/core/modals/ModalSearch.vue
+++ b/client/components/core/modals/ModalSearch.vue
@@ -206,30 +206,33 @@ export default {
     },
 
     listenKeys(event) {
-      if (event.keyCode === 27) {
-        document.removeEventListener('keyup', this.listenKeys)
-        this.onClose()
-        return true
+      if (event.keyCode === 27) this.cleanUp()
+      if (event.keyCode === 13) this.onEnter()
+    },
+
+    updateUrl() {
+      if (this.value && this.value.length) {
+        this.$router.push({ path: '/blog/search-result/', query: { searchBy: this.value } })
+      } else {
+        this.$router.push('/blog/')
       }
-      if (this.searchPosts && this.searchPosts.length) {
-        if (event.keyCode === 13) {
-          if (this.value && this.value.length) {
-            this.$router.push({ path: '/blog/search-result/', query: { searchBy: this.value } })
-          } else {
-            this.$router.push('/blog/')
-          }
-          document.removeEventListener('keyup', this.listenKeys)
-          this.onClose()
-          return true
-        }
-        return false
-      }
-      return true
+    },
+
+    cleanUp() {
+      document.removeEventListener('keyup', this.listenKeys)
+      this.onClose()
     },
 
     onClose() {
       this.$emit('on-close')
       this.response = null
+    },
+
+    onEnter() {
+      if (this.searchPosts && this.searchPosts.length) {
+        this.updateUrl()
+        this.cleanUp()
+      }
     },
   },
 }

--- a/client/pages/blog/search-result/index.vue
+++ b/client/pages/blog/search-result/index.vue
@@ -36,20 +36,7 @@ export default {
     posts() {
       if (!this.getSearchResponse || !this.getSearchResponse.results) return null
       if (!this.getSearchResponse || !this.getSearchResponse.results || !this.getSearchResponse.results.length) return []
-      this.$nextTick(() => {
-        this.resetLazyLoad()
-      })
       return this.getSearchResponse.results
-    },
-  },
-
-  watch: {
-    allAuthors(newVal) {
-      if (newVal && newVal.length) {
-        this.$nextTick(() => {
-          this.resetLazyLoad()
-        })
-      }
     },
   },
 

--- a/tests/components/core/modals/ModalSearch.spec.js
+++ b/tests/components/core/modals/ModalSearch.spec.js
@@ -1,250 +1,367 @@
 import 'regenerator-runtime/runtime'
-import { render } from '@testing-library/vue'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vuex from 'vuex'
 import ModalSearch from '@/components/core/modals/ModalSearch'
 
-describe('ModalSearch component', () => {
-  const store = {
-    actions: {
-      setSearchResponse: () => '',
-      getBlogTags: jest.fn(),
-    },
-    getters: {
-      allAuthors() {
-        return [
-          {
-            id: '123',
-            position: 'Senior',
-          },
-        ]
-      },
-      blogTags() {
-        return []
-      },
-    },
-  }
+const localVue = createLocalVue()
+localVue.use(Vuex)
 
-  it('should render correctly', () => {
-    const { container } = render(ModalSearch, {
+const mocks = {
+  $refs: {
+    searchInput: {
+      focus: () => null,
+    },
+  },
+  $prismic: {
+    api: {
+      tags: ['iOS'],
+      query: jest.fn(() => Promise.resolve('response')),
+    },
+    predicates: {
+      fulltext: jest.fn(),
+    },
+  },
+  $router: {
+    push: () => null,
+  },
+}
+
+const actions = {
+  setSearchResponse: () => '',
+  getBlogTags: () => null,
+}
+
+const getters = {
+  allAuthors: () => [{ id: '123', position: 'Senior' }],
+  blogTags: () => [],
+}
+
+const store = new Vuex.Store({
+  actions,
+  getters,
+})
+
+describe('ModalSearch component', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        response: {},
+      }),
+      localVue,
+      mocks,
       store,
     })
-    expect(container).toMatchSnapshot()
   })
 
-  // TODO need to rewrite this test cases
-  /* eslint-disable */
-  //
-  // beforeEach(() => {
-  //   wrapper = mount(ModalSearch, {
-  //     data: () => ({
-  //       response: {
-  //         results: [],
-  //       },
-  //     }),
-  //     mocks,
-  //   })
-  // })
-  //
-  // it('should render correctly', () => {
-  //   expect(wrapper).toMatchSnapshot()
-  // })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
-  // it('if set data with date Thu May 20 2021 16:52:46 GMT+0600 to formattedDate will return May 20, 2021', () => {
-  //   const post = {
-  //     data: {
-  //       date: 'Thu May 20 2021 16:52:46 GMT+0600',
-  //     },
-  //   }
-  //   expect(wrapper.vm.formattedDate(post)).toBe('May 20, 2021')
-  // })
-  //
-  // describe('searchPosts', () => {
-  //   it('if response === null > searchPosts will return []', () => {
-  //     wrapper = shallowMount(ModalSearch, {
-  //       data: () => ({
-  //         response: {},
-  //       }),
-  //       mocks,
-  //     })
-  //     expect(wrapper.vm.searchPosts).toEqual([])
-  //   })
-  //
-  //   it('if response has not key "results" searchPosts will return []', () => {
-  //     wrapper = shallowMount(ModalSearch, {
-  //       data: () => ({
-  //         response: {},
-  //       }),
-  //       mocks,
-  //     })
-  //     expect(wrapper.vm.searchPosts).toEqual([])
-  //   })
-  //
-  //   it('if key "results" is empty > searchPosts will return []', () => {
-  //     wrapper = shallowMount(ModalSearch, {
-  //       data: () => ({
-  //         response: {
-  //           results: [],
-  //         },
-  //       }),
-  //       mocks,
-  //     })
-  //     expect(wrapper.vm.searchPosts).toEqual([])
-  //   })
-  //
-  //   it('if key "results" has data > searchPosts will return data', () => {
-  //     wrapper = shallowMount(ModalSearch, {
-  //       data: () => ({
-  //         response: {
-  //           results: [
-  //             {
-  //               data: {
-  //                 date: 'Thu May 20 2021 16:52:46 GMT+0600',
-  //                 featured_image: {
-  //                   url: 'http://localhost',
-  //                 },
-  //                 title: [
-  //                   {
-  //                     text: '',
-  //                   },
-  //                 ],
-  //               },
-  //             },
-  //           ],
-  //         },
-  //       }),
-  //       mocks,
-  //       stubs: ['NuxtLink'],
-  //     })
-  //     expect(wrapper.vm.searchPosts).toHaveLength(1)
-  //   })
-  //
-  //   it('test sorting for searchPosts', () => {
-  //     wrapper = shallowMount(ModalSearch, {
-  //       data: () => ({
-  //         response: {
-  //           results: [
-  //             {
-  //               data: {
-  //                 id: 1,
-  //                 date: 'Thu May 19 2020 11:22:01 GMT+0600',
-  //                 featured_image: {
-  //                   url: 'http://localhost',
-  //                 },
-  //                 title: [
-  //                   {
-  //                     text: '',
-  //                   },
-  //                 ],
-  //               },
-  //             },
-  //             {
-  //               data: {
-  //                 id: 2,
-  //                 date: 'Thu May 20 2021 16:52:46 GMT+0600',
-  //                 featured_image: {
-  //                   url: 'http://localhost',
-  //                 },
-  //                 title: [
-  //                   {
-  //                     text: '',
-  //                   },
-  //                 ],
-  //               },
-  //             },
-  //           ],
-  //         },
-  //       }),
-  //       mocks,
-  //       stubs: ['NuxtLink'],
-  //     })
-  //     expect(wrapper.vm.searchPosts[0].data.id).toBe(2)
-  //     expect(wrapper.vm.searchPosts[1].data.id).toBe(1)
-  //   })
-  // })
-  //
-  // it('if set to args Frontend Development > tagLink will return /blog/tag/frontend-development/', () => {
-  //   wrapper = shallowMount(ModalSearch, {
-  //     mocks,
-  //   })
-  //   expect(wrapper.vm.tagLink('Frontend Development')).toEqual('/blog/tag/frontend-development/')
-  // })
-  //
-  // it('if set to 2 arg position > getAuthor will return Senior', () => {
-  //   wrapper = shallowMount(ModalSearch, {
-  //     localVue,
-  //     store,
-  //     mocks: {
-  //       ...mocks,
-  //     },
-  //   })
-  //   const post = {
-  //     data: {
-  //       post_author: {
-  //         id: '123',
-  //       },
-  //     },
-  //   }
-  //   expect(wrapper.vm.getAuthor(post, 'position')).toEqual('Senior')
-  // })
-  //
-  // it('if post arg is empty > getAuthor will return null', () => {
-  //   wrapper = shallowMount(ModalSearch, {
-  //     localVue,
-  //     store,
-  //     mocks: {
-  //       ...mocks,
-  //     },
-  //   })
-  //   const post = undefined
-  //   expect(wrapper.vm.getAuthor(post, 'position')).toBeNull()
-  // })
-  //
-  // it('if field arg is empty > getAuthor will return null', () => {
-  //   wrapper = shallowMount(ModalSearch, {
-  //     localVue,
-  //     store,
-  //     mocks: {
-  //       ...mocks,
-  //     },
-  //   })
-  //   const post = {
-  //     data: {
-  //       post_author: {
-  //         id: '123',
-  //       },
-  //     },
-  //   }
-  //   expect(wrapper.vm.getAuthor(post)).toBeNull()
-  // })
-  //
-  // it('if post obj dosnt have key "id" > getAuthor will return null', () => {
-  //   wrapper = shallowMount(ModalSearch, {
-  //     localVue,
-  //     store,
-  //     mocks: {
-  //       ...mocks,
-  //     },
-  //   })
-  //   const post = {
-  //     data: {
-  //       post_author: {},
-  //     },
-  //   }
-  //   expect(wrapper.vm.getAuthor(post)).toBeNull()
-  // })
-  //
-  // it('if call onClose method > data response will be null', () => {
-  //   wrapper = shallowMount(ModalSearch, {
-  //     localVue,
-  //     store,
-  //     mocks: {
-  //       ...mocks,
-  //     },
-  //     data: () => ({
-  //       response: [{}, {}],
-  //     }),
-  //   })
-  //   expect(wrapper.vm.response).toEqual([{}, {}])
-  //   wrapper.vm.onClose()
-  //   expect(wrapper.vm.response).toBeNull()
-  // })
+  it('should render correctly', () => {
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('if set data with date Thu May 20 2021 16:52:46 GMT+0600 to formattedDate will return May 20, 2021', () => {
+    const post = {
+      data: {
+        date: 'Thu May 20 2021 16:52:46 GMT+0600',
+      },
+    }
+    expect(wrapper.vm.formattedDate(post)).toBe('May 20, 2021')
+  })
+
+  it('if response === null, searchPosts will return []', () => {
+    expect(wrapper.vm.searchPosts).toEqual([])
+  })
+
+  it('if response has not key "results" searchPosts will return []', () => {
+    expect(wrapper.vm.searchPosts).toEqual([])
+  })
+
+  it('if key "results" is empty, searchPosts will return []', () => {
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        response: {
+          results: [],
+        },
+      }),
+      localVue,
+      mocks,
+      store,
+    })
+    expect(wrapper.vm.searchPosts).toEqual([])
+  })
+
+  it('if key "results" has data, searchPosts will return array with data', () => {
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        response: {
+          results: [
+            {
+              data: {
+                date: 'Thu May 20 2021 16:52:46 GMT+0600',
+                featured_image: {
+                  url: 'http://localhost',
+                },
+                title: [
+                  {
+                    text: '',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      stubs: ['NuxtLink'],
+      localVue,
+      mocks,
+      store,
+    })
+    expect(wrapper.vm.searchPosts).toHaveLength(1)
+  })
+
+  it('searchPosts should sort array items by date', () => {
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        response: {
+          results: [
+            {
+              data: {
+                id: 1,
+                date: 'Thu May 19 2020 11:22:01 GMT+0600',
+                featured_image: {
+                  url: 'http://localhost',
+                },
+                title: [
+                  {
+                    text: '',
+                  },
+                ],
+              },
+            },
+            {
+              data: {
+                id: 2,
+                date: 'Thu May 20 2021 16:52:46 GMT+0600',
+                featured_image: {
+                  url: 'http://localhost',
+                },
+                title: [
+                  {
+                    text: '',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      stubs: ['NuxtLink'],
+      localVue,
+      mocks,
+      store,
+    })
+    expect(wrapper.vm.searchPosts[0].data.id).toBe(2)
+    expect(wrapper.vm.searchPosts[1].data.id).toBe(1)
+  })
+
+  it('if set to args Frontend Development, tagLink will return /blog/tag/frontend-development/', () => {
+    expect(wrapper.vm.tagLink('Frontend Development')).toEqual('/blog/tag/frontend-development/')
+  })
+
+  it('if set to 2 arg position, getAuthor will return Senior', () => {
+    const post = {
+      data: {
+        post_author: {
+          id: '123',
+        },
+      },
+    }
+    expect(wrapper.vm.getAuthor(post, 'position')).toEqual('Senior')
+  })
+
+  it('if post arg is empty, getAuthor will return null', () => {
+    const post = undefined
+    expect(wrapper.vm.getAuthor(post, 'position')).toBeNull()
+  })
+
+  it('if field arg is empty, getAuthor will return null', () => {
+    const post = {
+      data: {
+        post_author: {
+          id: '123',
+        },
+      },
+    }
+    expect(wrapper.vm.getAuthor(post)).toBeNull()
+  })
+
+  it('if post obj dosnt have key "id", getAuthor will return null', () => {
+    const post = {
+      data: {
+        post_author: {},
+      },
+    }
+    expect(wrapper.vm.getAuthor(post)).toBeNull()
+  })
+
+  it('if call onClose method, data response will be null', () => {
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        response: [{}, {}],
+      }),
+      localVue,
+      mocks,
+      store,
+    })
+    expect(wrapper.vm.response).toEqual([{}, {}])
+    wrapper.vm.onClose()
+    expect(wrapper.vm.response).toBeNull()
+  })
+
+  it('onEnter should call cleanUp and updateUrl methods, if this.searchPosts is not empty', () => {
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        response: {
+          results: [
+            {
+              data: {
+                id: 1,
+                date: 'Thu May 19 2020 11:22:01 GMT+0600',
+                featured_image: {
+                  url: 'http://localhost',
+                },
+                title: [
+                  {
+                    text: '',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      stubs: ['NuxtLink'],
+      localVue,
+      mocks,
+      store,
+    })
+
+    const spyUpdateUrl = jest.spyOn(wrapper.vm, 'updateUrl')
+    const spyCleanUp = jest.spyOn(wrapper.vm, 'cleanUp')
+
+    wrapper.vm.onEnter()
+
+    expect(spyUpdateUrl).toHaveBeenCalledTimes(1)
+    expect(spyCleanUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('onEnter should not call cleanUp and updateUrl methods, if this.searchPosts is empty', () => {
+    const spyUpdateUrl = jest.spyOn(wrapper.vm, 'updateUrl')
+    const spyCleanUp = jest.spyOn(wrapper.vm, 'cleanUp')
+
+    wrapper.vm.onEnter()
+
+    expect(spyUpdateUrl).not.toHaveBeenCalledTimes(1)
+    expect(spyCleanUp).not.toHaveBeenCalledTimes(1)
+  })
+
+  it('should remove event listener and call onClose method', () => {
+    const spyRemoveEventListener = jest.spyOn(document, 'removeEventListener')
+    const spyOnClose = jest.spyOn(wrapper.vm, 'onClose')
+    const callback = wrapper.vm.listenKeys
+
+    wrapper.vm.cleanUp()
+
+    expect(spyOnClose).toHaveBeenCalledTimes(1)
+    expect(spyRemoveEventListener).toHaveBeenCalledTimes(1)
+    expect(spyRemoveEventListener).toHaveBeenCalledWith('keyup', callback)
+  })
+
+  it('should call cleanUp method if event.keyCode equal 27', () => {
+    const spyCleanUp = jest.spyOn(wrapper.vm, 'cleanUp')
+    const spyOnEnter = jest.spyOn(wrapper.vm, 'onEnter')
+    const event = {
+      keyCode: 27,
+    }
+
+    wrapper.vm.listenKeys(event)
+
+    expect(spyCleanUp).toHaveBeenCalledTimes(1)
+    expect(spyOnEnter).toHaveBeenCalledTimes(0)
+  })
+
+  it('should call onEnter method if event.keyCode equal 13', () => {
+    const spyCleanUp = jest.spyOn(wrapper.vm, 'cleanUp')
+    const spyOnEnter = jest.spyOn(wrapper.vm, 'onEnter')
+    const event = {
+      keyCode: 13,
+    }
+
+    wrapper.vm.listenKeys(event)
+
+    expect(spyOnEnter).toHaveBeenCalledTimes(1)
+    expect(spyCleanUp).toHaveBeenCalledTimes(0)
+  })
+
+  it('should call push method with searchBy params if this.value is not empty', () => {
+    const args = { path: '/blog/search-result/', query: { searchBy: 'test' } }
+    const spyPush = jest.spyOn(mocks.$router, 'push')
+
+    wrapper = shallowMount(ModalSearch, {
+      data: () => ({
+        value: 'test',
+      }),
+      stubs: ['NuxtLink'],
+      localVue,
+      mocks,
+      store,
+    })
+
+    wrapper.vm.updateUrl()
+
+    expect(spyPush).toHaveBeenCalledWith(args)
+  })
+
+  it('should push to blog page if this.value is empty', () => {
+    const args = '/blog/'
+    const spyPush = jest.spyOn(mocks.$router, 'push')
+
+    wrapper.vm.updateUrl()
+
+    expect(spyPush).toHaveBeenCalledWith(args)
+  })
+
+  it('getPosts should call prismic api query and setSearchResponse with response params', async () => {
+    const spySetSearchResponse = jest.spyOn(wrapper.vm, 'setSearchResponse')
+
+    await wrapper.vm.getPosts()
+
+    expect(mocks.$prismic.api.query).toHaveBeenCalledTimes(1)
+    expect(spySetSearchResponse).toHaveBeenCalledTimes(1)
+    expect(spySetSearchResponse).toHaveBeenCalledWith('response')
+  })
+
+  it('getPosts should call prismic predicates fulltext with params', async () => {
+    const args = ['my.post.title', 'test']
+
+    await wrapper.vm.getPosts('test')
+
+    expect(mocks.$prismic.predicates.fulltext).toHaveBeenCalledTimes(1)
+    expect(mocks.$prismic.predicates.fulltext).toHaveBeenCalledWith(...args)
+  })
+
+  it('function should return post link', () => {
+    const post = {
+      type: 'post',
+      uid: 'post-uid',
+    }
+
+    const value = wrapper.vm.link(post)
+
+    expect(value).toBe('/blog/post-uid/')
+  })
 })

--- a/tests/components/core/modals/__snapshots__/ModalSearch.spec.js.snap
+++ b/tests/components/core/modals/__snapshots__/ModalSearch.spec.js.snap
@@ -1,55 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ModalSearch component should render correctly 1`] = `
-<div>
-  <section
-    class="modal-search"
-  >
-    <div
-      class="container"
-    >
-      <div
-        class="modal-search_form"
-      >
-        <label>
-          <img
-            alt="Magnify"
-            class="modal-search_form-search"
-            height="35"
-            src="@/assets/img/common/magnify.svg"
-            width="30"
-          />
-           
-          <input
-            placeholder="Search"
-            type="text"
-          />
-        </label>
-         
-        <button
-          class="modal-search_form-close"
-        >
-          <img
-            alt="Close"
-            height="24"
-            src="@/assets/img/common/close-icon-search.svg"
-            width="24"
-          />
-        </button>
-      </div>
-       
-      <!---->
-       
-      <div
-        class="modal-search_not-found"
-      >
-        
+<section class="modal-search">
+  <div class="container">
+    <div class="modal-search_form"><label><img src="@/assets/img/common/magnify.svg" width="30" height="35" alt="Magnify" class="modal-search_form-search"> <input type="text" placeholder="Search"></label> <button class="modal-search_form-close"><img src="@/assets/img/common/close-icon-search.svg" width="24" height="24" alt="Close"></button></div>
+    <!---->
+    <div class="modal-search_not-found">
       No results found
-    
-      </div>
-       
-      <!---->
     </div>
-  </section>
-</div>
+    <!---->
+  </div>
+</section>
 `;


### PR DESCRIPTION
1. Refactored `listenKeys` function 
2. Added new tests for `ModalSearch` component
3. Remove unuse `resetLazyLoad` method, fix this bug: https://maddevs.atlassian.net/browse/MAR-1944
4. Task: https://maddevs.atlassian.net/browse/MAR-1659