### PR TITLE
MAR-2015.  Fixed error "Cannot read properties of undefined (reading 'removeEventListener')"

### DIFF
--- a/client/components/Cases/sjmc/SJMCVideo.vue
+++ b/client/components/Cases/sjmc/SJMCVideo.vue
@@ -76,7 +76,7 @@ export default {
   },
 
   destroyed() {
-    this.$refs.video.removeEventListener('ended', this.onEnded)
+    this.$refs.video?.removeEventListener('ended', this.onEnded)
   },
 
   methods: {


### PR DESCRIPTION
1) https://maddevs.atlassian.net/browse/MAR-2015
2) Fixed error "Cannot read properties of undefined (reading 'removeEventListener')"