### PR TITLE
MAR-2087 Removed subsection Others in Clients и Insights sections 

### DIFF
--- a/client/components/core/HeaderV2/HeaderMobile/HeaderMobileMenu.vue
+++ b/client/components/core/HeaderV2/HeaderMobile/HeaderMobileMenu.vue
@@ -4,6 +4,7 @@
     class="header-mobile-menu"
   >
     <button
+      v-show="menuName"
       type="button"
       class="header-mobile-menu__button"
       @click="open"

--- a/client/components/core/HeaderV2/HeaderMobile/HeaderMobileSection.vue
+++ b/client/components/core/HeaderV2/HeaderMobile/HeaderMobileSection.vue
@@ -71,7 +71,7 @@ export default {
   computed: {
     mappedMenus() {
       const otherMenu = {
-        name: 'Other',
+        name: null,
         routes: [],
       }
       const filteredMenus = this.menus.filter(({ name }) => Boolean(name))


### PR DESCRIPTION
Task: https://maddevs.atlassian.net/browse/MAR-2087

A quick touch up of HeaderMobileMenu.vue and HeaderMobileSection.vue to eliminate "Others" subsection in non-nested sections
![image](https://user-images.githubusercontent.com/89966206/134162768-74b42cfd-b524-4341-acfc-e669a27dae91.png)
