### PR TITLE
Mar-2086 minor fixes in new sections

### DIFF
--- a/client/components/DeliveryModels/Banner.vue
+++ b/client/components/DeliveryModels/Banner.vue
@@ -26,7 +26,7 @@
         :style="{opacity: sectionTextOpacity}"
       >
         <h1 class="delivery-model-banner__title">
-          Delivery <br> models
+          Delivery models
         </h1>
         <p class="delivery-model-banner__subtitle">
           At Mad Devs, we provide a full range of services aimed at delivering long-term value for both our customers and end users.
@@ -76,42 +76,30 @@ export default {
     text-align: center;
   }
   &__title {
-    color: $text-color--white;
-    font-size: 100px;
-    line-height: 96px;
-    letter-spacing: -0.04em;
+    @include font('Inter', 100px, 800);
+    line-height: 105px;
+    letter-spacing: -2px;
+    color: $text-color--white-primary;
   }
   &__subtitle {
-    margin-top: 55px;
-    font-size: 32px;
+    @include font('Inter', 32px, 600);
     line-height: 44px;
-    letter-spacing: -0.013em;
-    color: $text-color--silver;
+    letter-spacing: -1px;
+    margin-top: 20px;
+    color: $text-color--white-primary;
   }
 
   @media screen and (max-width: 1120px) {
     padding-top: 48px;
   }
 
-  @media screen and (max-width: 1024px) {
-    &__title {
-      font-size: 80px;
-      line-height: 88px;
-    }
-    &__subtitle {
-      margin-top: 35px;
-      font-size: 24px;
-      line-height: 34px;
-    }
-  }
-
   @media screen and (max-width: 768px) {
     &__title {
-      font-size: 52px;
-      line-height: 57px;
+      font-size: 56px;
+      line-height: 48px;
     }
     &__subtitle {
-      margin-top: 30px;
+      margin-top: 8px;
       font-size: 21px;
       line-height: 30px;
     }

--- a/client/components/core/Privacy.vue
+++ b/client/components/core/Privacy.vue
@@ -662,6 +662,7 @@ export default {
 
   &__title {
     @include h2-title;
+    @include font('Inter', 62px, 700);
   }
 
   &__sec-title {

--- a/client/prismicSlices/pageParts/StartScreen/index.vue
+++ b/client/prismicSlices/pageParts/StartScreen/index.vue
@@ -123,7 +123,7 @@ export default {
       line-height: 48px;
     }
     /deep/ .large {
-      @include font('Inter', 110px, 800);
+      @include font('Inter', 100px, 800);
       line-height: 105px;
       @media screen and (max-width: 768px) {
         font-size: 56px;
@@ -135,7 +135,7 @@ export default {
     @include font('Inter', 32px, 600);
     line-height: 44px;
     letter-spacing: -1px;
-    margin-top: 10px;
+    margin-top: 20px;
     color: $text-color--white-primary;
     @media screen and (max-width: 1024px) {
       font-size: 32px;

--- a/tests/unit/components/DeliveryModels/__snapshots__/Banner.spec.js.snap
+++ b/tests/unit/components/DeliveryModels/__snapshots__/Banner.spec.js.snap
@@ -34,9 +34,7 @@ exports[`Banner component should render correctly 1`] = `
           class="delivery-model-banner__title"
         >
           
-        Delivery 
-          <br />
-           models
+        Delivery models
       
         </h1>
          


### PR DESCRIPTION
**Task**: https://maddevs.atlassian.net/browse/MAR-2086

**Done**: 
increased spacing and decreased font-size to 100 in StartScreen slice. 
![image](https://user-images.githubusercontent.com/89966206/134217024-a3061464-a432-4fb4-b000-b32ee103a58e.png)

Adjusted Delivery Models Section to look identical to the StartScreen slice.
![image](https://user-images.githubusercontent.com/89966206/134217532-d4da72ac-229d-4b66-9e1d-eb8a863e58d3.png)


Changed font-family to Inter in privacy section
![image](https://user-images.githubusercontent.com/89966206/134217430-f2f28a47-d706-48b3-a25b-117b3cd19276.png)

