### PR TITLE
MAR-2203. Deleted padding from .ebook-read & added padding to .&__title

### DIFF
--- a/client/components/Ebook/Read.vue
+++ b/client/components/Ebook/Read.vue
@@ -1,14 +1,18 @@
 <template>
   <section
-    id="read-online-anchor"
     class="ebook-read"
   >
     <div class="container">
-      <h2 class="ebook-read__title">
+      <h2
+        id="read-online-anchor"
+        class="ebook-read__title"
+      >
         Read articles online
       </h2>
 
-      <div class="ebook-read__cards">
+      <div
+        class="ebook-read__cards"
+      >
         <ReadCard
           v-for="(post, i) of posts"
           :key="`post-card_${i}`"
@@ -101,7 +105,6 @@ export default {
 
 <style lang="scss" scoped>
 .ebook-read {
-  padding: 96px 0 64px;
   background-color: #fff;
 
   &__form {
@@ -128,11 +131,8 @@ export default {
     }
 
     @media screen and (max-width: 540px) {
-      margin-bottom: 48px;
-    }
-
-    @media screen and (max-width: 540px) {
       padding: 32px 38px;
+      margin-bottom: 0;
     }
 
     @media screen and (max-width: 376px) {
@@ -192,11 +192,8 @@ export default {
     padding: 64px 0 56px;
   }
 
-  @media screen and (max-width: 540px) {
-    padding: 72px 0;
-  }
-
   &__title {
+    padding: 96px 0 64px;
     width: 100%;
     @include font('Inter', 42px, 600);
     line-height: 46px;
@@ -211,6 +208,8 @@ export default {
     @media screen and (max-width: 540px) {
       @include font('Inter', 28px, 600);
       line-height: 32px;
+      padding: 72px 0;
+      margin-bottom: 0;
     }
   }
 

--- a/tests/unit/components/Ebook/__snapshots__/Read.spec.js.snap
+++ b/tests/unit/components/Ebook/__snapshots__/Read.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Read component should render correctly with no data 1`] = `
-<section id="read-online-anchor" class="ebook-read">
+<section class="ebook-read">
   <div class="container">
-    <h2 class="ebook-read__title">
+    <h2 id="read-online-anchor" class="ebook-read__title">
       Read articles online
     </h2>
     <div class="ebook-read__cards"></div>


### PR DESCRIPTION
Link to the task: https://maddevs.atlassian.net/browse/MAR-2203
1. Deleted padding from ebook-read and added padding to &__titile
2. The anchor link was postponed from ebook-read to h2 tag
3. Updated styles

![Screenshot from 2021-10-04 05-52-11](https://user-images.githubusercontent.com/64611024/135800649-3420c901-fa87-47b2-a9fe-f9e70f14ae32.png)
