### PR TITLE
MAR-2548. add "sticky" style to form on ebook page

### DIFF
--- a/client/assets/styles/_base.scss
+++ b/client/assets/styles/_base.scss
@@ -36,6 +36,9 @@ main {
   position: relative;
   overflow: hidden;
   z-index: 1;
+  &.ebook-page{
+    overflow: initial;  // for correct working "sticky position" property
+  }
 }
 
 * {

--- a/client/components/Ebook/Read.vue
+++ b/client/components/Ebook/Read.vue
@@ -121,12 +121,17 @@ export default {
     border-radius: 4px;
     box-sizing: border-box;
     align-self: flex-start;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 159px; // 96px from header to form
+    margin-bottom: 55px;
 
     @media only screen and (min-width: 1024px) and (max-width: 1094px) {
       width: 364px;
     }
 
     @media screen and (max-width: 992px) {
+      position: inherit;
       width: 100%;
       max-width: 100%;
       margin-bottom: 96px;


### PR DESCRIPTION
task: 
https://maddevs.atlassian.net/browse/MAR-2548

description: 
Add "sticky" style to form on ebook page
Add css properties for mobile and tablet screen
Remove "overflow: hidden" from "main" tag on ebook-page (need for correct work sticky prop)

test:
![image](https://user-images.githubusercontent.com/95682068/145802552-1561749c-4896-4440-8864-23d30eca1be8.png)


example:
 https://www.loom.com/share/ee650cf52f164ba690ed1cb9dde3930b