### PR TITLE
MAR-2643. Deleted breakpoint 900px in the CtaBannerSlice.vue

### DIFF
--- a/client/prismicSlices/pageParts/CtaBannerSlice/index.vue
+++ b/client/prismicSlices/pageParts/CtaBannerSlice/index.vue
@@ -188,9 +188,6 @@ export default {
     @media screen and (max-width: 992px) {
       max-width: 350px;
     }
-    @media screen and (max-width: 900px) {
-      max-width: 320px;
-    }
     @media screen and (max-width: 768px) {
       max-width: 100%;
       font-size: 17px;


### PR DESCRIPTION
The task: https://maddevs.atlassian.net/browse/MAR-2643

1. Deleted breakpoint 900px from the CtaBannerSlice for correctly render

![image](https://user-images.githubusercontent.com/64611024/146159169-6603f006-0746-4ecc-a08a-e0ed892595f9.png)


