### PR TITLE
MAR-3040. Fixed color styles in the component

### DIFF
--- a/client/components/shared/Crumbs.vue
+++ b/client/components/shared/Crumbs.vue
@@ -93,10 +93,10 @@ li {
 }
 
 li:after {
-  content: ' » ';
+  content: ' > ';
   display: inline;
   font-size: 12px;
-  color: $text-color--grey-pale;
+  color: $text-color--quote-box;
   padding: 0 0.0725em 0 0.15em;
 }
 
@@ -107,18 +107,16 @@ li:last-child:after {
 li a,
 li span {
   text-decoration: none;
-  color: $text-color--grey-pale;
   font-size: 12px;
   line-height: 166%;
   letter-spacing: -0.1px;
 }
 
 li span {
- color: $text-color--gainsboro;
- pointer-events: none;
+ color: $text-color--quote-box;
 }
 
-li a:hover {
-  text-decoration: underline;
+li span:hover {
+  color: $text-color--grey-pale;
 }
 </style>


### PR DESCRIPTION
the subtask: https://maddevs.atlassian.net/browse/MAR-3040

1. Fixed colors in the Crumbs component
2. Updated snapshots

<img width="502" alt="image" src="https://user-images.githubusercontent.com/64611024/159217185-ebc5e3ad-2bf9-4720-855f-cd4dad3deb65.png">
