### PR TITLE
MAR-3042. Refactored breadcrumbs

### DIFF
--- a/client/components/core/HeaderV2/index.vue
+++ b/client/components/core/HeaderV2/index.vue
@@ -378,6 +378,10 @@ export default {
         top: 70px;
         left: 0px;
       }
+
+      @media screen and (max-width: 768px) {
+        display: none;
+      }
     }
 
     @media screen and (max-width: 1012px) {

--- a/client/components/shared/Crumbs.vue
+++ b/client/components/shared/Crumbs.vue
@@ -36,9 +36,9 @@
         :event="(crumbs.length - 1) === i ? '' : 'click'"
         class="title"
         itemprop="item"
-        :title="crumb.title"
+        :title="(crumbs.length - 1) === i ? getTitle : crumb.title"
       >
-        <span itemprop="name">{{ crumb.title }}</span>
+        <span itemprop="name">{{ (crumbs.length - 1) === i ? getTitle : crumb.title }}</span>
         <meta
           itemprop="position"
           content="i + 1"
@@ -53,6 +53,10 @@ export default {
   name: 'Crumbs',
 
   computed: {
+    getTitle() {
+      return document.title
+    },
+
     crumbs() {
       const { fullPath } = this.$route
       const pathArray = fullPath.startsWith('/')
@@ -64,7 +68,7 @@ export default {
           to: breadcrumbArray[idx - 1]
             ? `/${breadcrumbArray[idx - 1].path}/${path}${path.endsWith('/') ? '' : '/'}`
             : `/${path}${path.endsWith('/') ? '' : '/'}`,
-          title: path.charAt(0).toUpperCase() + path.substr(1),
+          title: (path.charAt(0).toUpperCase() + path.substr(1)).replace(/-/gm, ' '),
         })
         return breadcrumbArray
       }, [])
@@ -96,7 +100,7 @@ li:after {
   content: ' > ';
   display: inline;
   font-size: 12px;
-  color: $text-color--quote-box;
+  color: $text-color--grey-20-percent;
   padding: 0 0.0725em 0 0.15em;
 }
 
@@ -113,10 +117,10 @@ li span {
 }
 
 li span {
- color: $text-color--quote-box;
+ color: $text-color--grey-20-percent;
 }
 
 li span:hover {
-  color: $text-color--grey-pale;
+  color: $text-color--cultured;
 }
 </style>

--- a/tests/unit/components/shared/Crumbs.spec.js
+++ b/tests/unit/components/shared/Crumbs.spec.js
@@ -14,7 +14,7 @@ describe('Crumbs component', () => {
       stubs,
     })
 
-    expect(wrapper.vm.crumbs).toEqual([{ to: '/blog/', title: 'Blog' }, { to: '/undefined/best-time-tracking-tools/', title: 'Best-time-tracking-tools' }])
+    expect(wrapper.vm.crumbs).toEqual([{ to: '/blog/', title: 'Blog' }, { to: '/undefined/best-time-tracking-tools/', title: 'Best time tracking tools' }])
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/tests/unit/components/shared/__snapshots__/Crumbs.spec.js.snap
+++ b/tests/unit/components/shared/__snapshots__/Crumbs.spec.js.snap
@@ -19,7 +19,7 @@ exports[`Crumbs component should correctly return data, when length of array gre
     </nuxtlink-stub>
   </li>
   <li itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem" class="item">
-    <nuxtlink-stub to="/undefined/best-time-tracking-tools/" event="" itemprop="item" title="Best-time-tracking-tools" class="title"><span itemprop="name">Best-time-tracking-tools</span>
+    <nuxtlink-stub to="/undefined/best-time-tracking-tools/" event="" itemprop="item" title="" class="title"><span itemprop="name"></span>
       <meta itemprop="position" content="i + 1">
     </nuxtlink-stub>
   </li>


### PR DESCRIPTION
the subtask: https://maddevs.atlassian.net/browse/MAR-3042

1. Fixed color styles
2. Fixed functional to get the route and titles for breadcrumbs
3. Updated tests and snapshots

<img width="754" alt="image" src="https://user-images.githubusercontent.com/64611024/159259320-6d0b2c9e-303d-4cb6-8b57-cc747cf2e70b.png">
