### PR TITLE
MAR-3466. Redesigned mobile adaptive for CardGridLottieSlice.

### DIFF
--- a/client/prismicSlices/pageParts/GridLottieSlice/variations/GridLottieLink.vue
+++ b/client/prismicSlices/pageParts/GridLottieSlice/variations/GridLottieLink.vue
@@ -131,7 +131,7 @@ export default {
       grid-column: auto;
     }
 
-    /deep/ .card-item__button {
+    ::v-deep .card-item__button {
       align-self: center;
       @media screen and (max-width: 1024px) {
         align-self: flex-start;
@@ -140,7 +140,7 @@ export default {
   }
 
   &--text-center {
-    /deep/ .card-item__content {
+    ::v-deep .card-item__content {
       align-self: center;
       text-align: center;
 
@@ -153,7 +153,7 @@ export default {
 
   &--lottie-bottom {
     padding-bottom: 0;
-    /deep/ .card-item {
+    ::v-deep .card-item {
       &__content {
         order: 1;
         font-size: 40px;
@@ -190,7 +190,7 @@ export default {
   }
 
   &:hover {
-    /deep/ .card-item__button {
+    ::v-deep .card-item__button {
       background-color: $text-color--white-primary;
       color: $text-color--black-oil;
     }
@@ -237,6 +237,9 @@ export default {
 
   &__button {
     order: 3;
+  }
+
+  ::v-deep .ui-arrow-button {
     @media screen and (max-width: 430px) {
       width: 30px;
       min-width: 30px;

--- a/client/prismicSlices/pageParts/GridLottieSlice/variations/GridLottieLink.vue
+++ b/client/prismicSlices/pageParts/GridLottieSlice/variations/GridLottieLink.vue
@@ -118,6 +118,13 @@ export default {
     }
   }
 
+  @media screen and (max-width: 430px) {
+    padding: 24px;
+    &--lottie-bottom {
+      padding-bottom: 0;
+    }
+  }
+
   &--full-width {
     grid-column: auto/span 2;
     @media screen and (max-width: 1024px) {
@@ -159,6 +166,11 @@ export default {
           font-size: 30px;
           line-height: 37px;
         }
+
+        @media screen and (max-width: 430px) {
+          font-size: 22px;
+          line-height: 26.63px;
+        }
       }
       &__button {
         order: 2;
@@ -168,6 +180,10 @@ export default {
         margin: 0 auto;
         @media screen and (max-width: 1024px) {
           margin-top: 56px;
+        }
+
+        @media screen and (max-width: 430px) {
+          margin-top: 24px;
         }
       }
     }
@@ -189,6 +205,10 @@ export default {
     @media screen and (max-width: 580px) {
       margin-bottom: 40px;
     }
+
+    @media screen and (max-width: 430px) {
+      margin-bottom: 24px;
+    }
   }
 
   &__content {
@@ -208,10 +228,21 @@ export default {
       font-size: 30px;
       line-height: 37px;
     }
+
+    @media screen and (max-width: 430px) {
+      font-size: 22px;
+      line-height: 26.63px;
+    }
   }
 
   &__button {
     order: 3;
+    @media screen and (max-width: 430px) {
+      width: 30px;
+      min-width: 30px;
+      height: 30px;
+      margin-top: 24px;
+    }
   }
 }
 </style>

--- a/client/prismicSlices/pageParts/GridLottieSlice/variations/GridWithAnimationOptionSlice.vue
+++ b/client/prismicSlices/pageParts/GridLottieSlice/variations/GridWithAnimationOptionSlice.vue
@@ -179,7 +179,7 @@ export default {
         text-align: left;
       }
     }
-    /deep/ p {
+    ::v-deep p {
       text-align: center;
 
       @media screen and (max-width: 1024px) {
@@ -229,7 +229,7 @@ export default {
       line-height: 23.8px;
     }
 
-    /deep/ p {
+    ::v-deep p {
       margin-top: 40px;
 
       @media screen and (max-width: 430px) {
@@ -237,7 +237,7 @@ export default {
       }
     }
 
-    /deep/ li {
+    ::v-deep li {
       font-weight: 400;
       margin-top: 7px;
 
@@ -246,7 +246,7 @@ export default {
       }
     }
 
-    /deep/ ul {
+    ::v-deep ul {
       li {
         &:before {
           content: '';

--- a/client/prismicSlices/pageParts/GridLottieSlice/variations/GridWithAnimationOptionSlice.vue
+++ b/client/prismicSlices/pageParts/GridLottieSlice/variations/GridWithAnimationOptionSlice.vue
@@ -126,6 +126,16 @@ export default {
     }
   }
 
+  @media screen and (max-width: 430px) {
+    padding: 24px;
+    &-bottom{
+      padding-bottom: 0;
+    }
+    &--without-lottie {
+      padding-bottom: 24px;
+    }
+  }
+
   &--full-width {
     grid-column: auto/span 2;
 
@@ -139,10 +149,20 @@ export default {
     height: 95px;
     margin-bottom: 60px;
     grid-area: lottie;
-    &-bottom{
+
+    @media screen and (max-width: 430px) {
+      margin-bottom: 24px;
+      height: 75px !important;
+    }
+
+    &-bottom {
       max-width: 689px;
       height: auto;
       margin: 40px auto 0;
+
+      @media screen and (max-width: 430px) {
+        height: 85px !important;
+      }
 
       @media screen and (max-width: 343px) {
         width: 289px;
@@ -179,6 +199,11 @@ export default {
       font-size: 30px;
       line-height: 37px;
     }
+
+    @media screen and (max-width: 430px) {
+      font-size: 22px;
+      line-height: 26.63px;
+    }
   }
 
   &__content {
@@ -199,8 +224,17 @@ export default {
       line-height: 30px;
     }
 
+    @media screen and (max-width: 430px) {
+      font-size: 16px;
+      line-height: 23.8px;
+    }
+
     /deep/ p {
       margin-top: 40px;
+
+      @media screen and (max-width: 430px) {
+        margin-top: 16px;
+      }
     }
 
     /deep/ li {


### PR DESCRIPTION
1. [Адаптировать шрифты на слайсе GridLottieSlice](https://maddevs.atlassian.net/browse/MAR-3466)
2. Redesigned mobile adaptive for CardGridLottieSlice.
    Fixed styles for arrow button.
    Replaced /deep/ to ::v-deep.

![image](https://user-images.githubusercontent.com/98309215/172843382-0ad5c2f6-6ec6-486a-afee-bf6f80e63a24.png)

![image](https://user-images.githubusercontent.com/98309215/172843471-a5bc6acb-2ed1-45a6-a5d5-104b3b8399ef.png)
