### PR TITLE
MAR-3555. Removed three dots from ebook cards.

### DIFF
--- a/client/components/Ebook/EbooksCard.vue
+++ b/client/components/Ebook/EbooksCard.vue
@@ -118,9 +118,8 @@ export default {
   }
 
   &__title {
-    @include font('Poppins', 22.78px, 600);
+    @include font('Poppins', 22px, 700);
     line-height: 130%;
-    letter-spacing: -1px;
     color: $text-color--chinese-black;
     margin-bottom: 10px;
   }

--- a/client/store/modules/ebooks.js
+++ b/client/store/modules/ebooks.js
@@ -16,10 +16,7 @@ export const state = () => ({
 export const mutations = {
   SET_EBOOKS(state, data) {
     state.ebooksDefault = data.results.map(ebook => ({
-      title: textEllipsis(this.$prismic.asText(ebook.data.body[0].primary.title), {
-        limit: 42,
-        trimToSpace: false,
-      }),
+      title: this.$prismic.asText(ebook.data.body[0].primary.title),
       subtitle: textEllipsis(this.$prismic.asText(ebook.data.body[0].primary.subtitle), {
         limit: 80,
         trimToSpace: false,


### PR DESCRIPTION
1. [MAR-3555: Показывать весь текс в названиях книжек](https://maddevs.atlassian.net/browse/MAR-3555)
2. Removed three dots from ebook cards.

![image](https://user-images.githubusercontent.com/98309215/178970892-690ee52d-a434-41a9-8672-d32e77303e2c.png)
